### PR TITLE
Upgrade Spring Boot to 4.1.1 and update dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Ryyppy.net is a web application for tracking alcohol consumption. Users can create parties and track their blood alcohol content (BAC) in real-time. The application calculates promille levels based on user weight, sex, and drink timestamps.
 
 **Tech Stack:**
-- Backend: Spring Boot 2.7.10 (Java 11)
+- Backend: Spring Boot 4.1.1 (Java 21)
 - Database: PostgreSQL (HSQLDB for testing)
 - Frontend: AngularJS (legacy), with experimental Backbone and Ember implementations
 - View Layer: JSP with JSTL

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.1</version>
     </parent>
 
     <groupId>net.ryyppy</groupId>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.13.0</version>
+            <version>2.14.3</version>
         </dependency>
         <!-- Spring framework -->
         <dependency>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
-            <version>2.7.2</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
Upgrade the application to Spring Boot 4.1.1 (from 4.0.1) and update key dependencies to their latest versions. This also updates the project documentation to reflect the new tech stack.

## Key Changes
- **Spring Boot**: Updated from 4.0.1 to 4.1.1
- **Joda-Time**: Updated from 2.13.0 to 2.14.3
- **Google API Client**: Updated from 2.7.2 to 2.9.0
- **Documentation**: Updated CLAUDE.md to reflect Spring Boot 4.1.1 and Java 21 (previously documented as Spring Boot 2.7.10 with Java 11)

## Notes
- These are minor/patch version updates that should maintain API compatibility
- The documentation update aligns the CLAUDE.md file with the actual tech stack being used
- No source code changes were required for these dependency updates

https://claude.ai/code/session_01AB6dL8nMUzHARZMxRVV1My