### PR TITLE
Fix Hibernate startup warnings: LOB probe and deprecated @Temporal

### DIFF
--- a/src/main/java/drinkcounter/DrinkCounterServiceImpl.java
+++ b/src/main/java/drinkcounter/DrinkCounterServiceImpl.java
@@ -22,6 +22,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -51,7 +52,7 @@ public class DrinkCounterServiceImpl implements DrinkCounterService {
 
         Party party = new Party();
         party.setName(partyName);
-        party.setStartTime(new Date());
+        party.setStartTime(Instant.now());
         partyDao.save(party);
 
         log.info("Party {}, id {} was started!", partyName, party.getId());
@@ -109,7 +110,7 @@ public class DrinkCounterServiceImpl implements DrinkCounterService {
         Drink drink = drinkDao.findById(drinkId).orElseThrow(EntityNotFoundException::new);
         user.removeDrink(drink);
         drinkDao.delete(drink);
-        log.info("{} has removed a drink {}", user, new DateTime(drink.getTimeStamp()).toString());
+        log.info("{} has removed a drink {}", user, new DateTime(drink.getTimeStamp().toEpochMilli()).toString());
     }
 
     @Override
@@ -129,7 +130,7 @@ public class DrinkCounterServiceImpl implements DrinkCounterService {
         if (date.after(new Date())) throw new IllegalArgumentException("date");
         User user = userDAO.findById(userId).orElseThrow(EntityNotFoundException::new);
         Drink drink = new Drink();
-        drink.setTimeStamp(date);
+        drink.setTimeStamp(date.toInstant());
         user.drink(drink);
         drinkDao.save(drink);
         log.info("{} has drunk a drink at {}", user, date.toString());
@@ -173,7 +174,7 @@ public class DrinkCounterServiceImpl implements DrinkCounterService {
     public int addDrink(int userId, float alcoholAmount) {
         User user = userDAO.findById(userId).orElseThrow(EntityNotFoundException::new);
         Drink drink = new Drink();
-        drink.setTimeStamp(new Date());
+        drink.setTimeStamp(Instant.now());
         drink.setAlcohol(alcoholAmount);
         user.drink(drink);
         drinkDao.save(drink);
@@ -187,9 +188,9 @@ public class DrinkCounterServiceImpl implements DrinkCounterService {
         User user = userDAO.findById(userId).orElseThrow(EntityNotFoundException::new);
         Drink drink = new Drink();
         if(date != null){
-            drink.setTimeStamp(date);
+            drink.setTimeStamp(date.toInstant());
         }else{
-            drink.setTimeStamp(new Date());
+            drink.setTimeStamp(Instant.now());
         }
         
         if(alcoholAmount != null){

--- a/src/main/java/drinkcounter/alcoholcalculator/AlcoholCalculator.java
+++ b/src/main/java/drinkcounter/alcoholcalculator/AlcoholCalculator.java
@@ -55,7 +55,7 @@ public class AlcoholCalculator {
     
     public void calculateDrink(Drink drink) {
         synchronized(this) {
-            double currentAlcohol = calculate(drink.getTimeStamp());
+            double currentAlcohol = calculate(Date.from(drink.getTimeStamp()));
 
             // If there is still alcohol to burn, then the last function will be "disabled" with a cutter
             int size = functions.size();
@@ -63,7 +63,7 @@ public class AlcoholCalculator {
                 functions.get(size - 1).setCutter(currentAlcohol);
             }
 
-            ShotFunction newFunction = new ShotFunction(drink.getTimeStamp(), burnRate, currentAlcohol + drink.getAlcohol());
+            ShotFunction newFunction = new ShotFunction(Date.from(drink.getTimeStamp()), burnRate, currentAlcohol + drink.getAlcohol());
             functions.add(newFunction);
         }
     }

--- a/src/main/java/drinkcounter/model/Drink.java
+++ b/src/main/java/drinkcounter/model/Drink.java
@@ -1,14 +1,15 @@
 package drinkcounter.model;
 
 import drinkcounter.alcoholcalculator.AlcoholCalculator;
-import java.util.Date;
+import java.time.Instant;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.Temporal;
 import jakarta.persistence.Transient;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /**
  *
@@ -21,11 +22,11 @@ import jakarta.persistence.Transient;
 public class Drink extends AbstractEntity {
 
     private User drinker;
-    private Date timeStamp;
+    private Instant timeStamp;
     private float alcohol = (float)AlcoholCalculator.STANDARD_DRINK_ALCOHOL_GRAMS;
 
     public Drink() {
-        timeStamp = new Date();
+        timeStamp = Instant.now();
     }
 
     @ManyToOne(fetch=FetchType.LAZY)
@@ -37,12 +38,14 @@ public class Drink extends AbstractEntity {
         this.drinker = drinkerKey;
     }
 
-    @Temporal(jakarta.persistence.TemporalType.TIMESTAMP)
-    public Date getTimeStamp() {
+    // Keep the existing "timestamp without time zone" column instead of Hibernate's
+    // default TIMESTAMP_UTC mapping for Instant, which would map to timestamptz.
+    @JdbcTypeCode(SqlTypes.TIMESTAMP)
+    public Instant getTimeStamp() {
         return timeStamp;
     }
 
-    public void setTimeStamp(Date timeStamp) {
+    public void setTimeStamp(Instant timeStamp) {
         this.timeStamp = timeStamp;
     }
 

--- a/src/main/java/drinkcounter/model/Party.java
+++ b/src/main/java/drinkcounter/model/Party.java
@@ -1,13 +1,14 @@
 package drinkcounter.model;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Temporal;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /**
  *
@@ -17,14 +18,16 @@ import jakarta.persistence.Temporal;
 public class Party extends AbstractEntity{
     private List<User> participants;
     private String name;
-    private Date startTime;
+    private Instant startTime;
 
-    public void setStartTime(Date startTime) {
+    public void setStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
-    @Temporal(jakarta.persistence.TemporalType.TIMESTAMP)
-    public Date getStartTime() {
+    // Keep the existing "timestamp without time zone" column instead of Hibernate's
+    // default TIMESTAMP_UTC mapping for Instant, which would map to timestamptz.
+    @JdbcTypeCode(SqlTypes.TIMESTAMP)
+    public Instant getStartTime() {
         return this.startTime;
     }
 

--- a/src/main/java/drinkcounter/model/User.java
+++ b/src/main/java/drinkcounter/model/User.java
@@ -155,7 +155,7 @@ public class User extends AbstractEntity{
         ListIterator<Drink> iterator = drinks.listIterator(drinks.size());
         while(iterator.hasPrevious()){
             Drink drink = iterator.previous();
-            if (drink.getTimeStamp().before(date))
+            if (drink.getTimeStamp().isBefore(date.toInstant()))
                 break;
             shots += drink.getAmountOfShots();
         }

--- a/src/main/java/drinkcounter/util/PartyMarshaller.java
+++ b/src/main/java/drinkcounter/util/PartyMarshaller.java
@@ -76,7 +76,7 @@ public class PartyMarshaller {
 
         if (user.getDrinks().size() > 0) {
             Drink lastDrink = user.getDrinks().get(user.getDrinks().size() - 1);
-            long millis = System.currentTimeMillis() - lastDrink.getTimeStamp().getTime();
+            long millis = System.currentTimeMillis() - lastDrink.getTimeStamp().toEpochMilli();
             String seconds = Long.toString(millis / 1000);
             userNode.appendChild(createTextContentElement("idle", seconds, doc));
         } else {
@@ -99,7 +99,7 @@ public class PartyMarshaller {
             i++;
             Drink drink = iter.previous();
             Node drinkNode = d.createElement("drink");
-            DateTime dateTime = new DateTime(drink.getTimeStamp());
+            DateTime dateTime = new DateTime(drink.getTimeStamp().toEpochMilli());
 
             drinkNode.appendChild(createTextContentElement("id", Integer.toString(drink.getId()), d));
             drinkNode.appendChild(createTextContentElement("timestamp", Long.toString(dateTime.toInstant().getMillis()), d));

--- a/src/main/java/drinkcounter/web/controllers/api/APIController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/APIController.java
@@ -132,7 +132,7 @@ public class APIController {
         String format = "YYYY-MM-dd";
 
         for (Drink d : drinks) {
-            DateTime dt = new DateTime(d.getTimeStamp());
+            DateTime dt = new DateTime(d.getTimeStamp().toEpochMilli());
             double timezoneOffset = (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
             DateTimeZone dtz = DateTimeZone.forOffsetMillis((int)(-timezoneOffset * 60 * 1000));
             dt = dt.toDateTime(dtz);

--- a/src/main/java/drinkcounter/web/controllers/api/v2/PartyDTO.java
+++ b/src/main/java/drinkcounter/web/controllers/api/v2/PartyDTO.java
@@ -55,7 +55,7 @@ public class PartyDTO {
         PartyDTO partyDTO = new PartyDTO();
         partyDTO.setId(party.getId());
         partyDTO.setName(party.getName());
-        partyDTO.setStartTime(party.getStartTime());
+        partyDTO.setStartTime(Date.from(party.getStartTime()));
         return partyDTO;
     }
 }

--- a/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
@@ -88,7 +88,7 @@ public class ProfileApiController {
         for (Drink drink : drinks) {
             DrinkDTO drinkDTO = new DrinkDTO();
             drinkDTO.setId(drink.getId());
-            drinkDTO.setTimestamp(new DateTime(drink.getTimeStamp()).toString());
+            drinkDTO.setTimestamp(new DateTime(drink.getTimeStamp().toEpochMilli()).toString());
             drinkDTO.setAmountOfShots(drink.getAmountOfShots());
             drinkDTOs.add(drinkDTO);
         }
@@ -109,7 +109,7 @@ public class ProfileApiController {
         String format = "YYYY-MM-dd";
 
         for (Drink d : drinks) {
-            DateTime dt = new DateTime(d.getTimeStamp());
+            DateTime dt = new DateTime(d.getTimeStamp().toEpochMilli());
             double timezoneOffset = 0; // (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
             DateTimeZone dtz = DateTimeZone.forOffsetMillis((int)(-timezoneOffset * 60 * 1000));
             dt = dt.toDateTime(dtz);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
       hibernate:
         jdbc:
           lob:
+            # Skip Hibernate's Connection.createClob() capability probe at
+            # startup. CockroachDB (used in production on Railway) doesn't
+            # implement it and throws SQLFeatureNotSupportedException, which
+            # Hibernate catches and logs noisily even though it's harmless -
+            # we have no @Lob fields, so force the in-memory LOB creator
+            # instead of probing for one.
             non_contextual_creation: true
   session:
     timeout: 90d

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        jdbc:
+          lob:
+            non_contextual_creation: true
   session:
     timeout: 90d
     jdbc:

--- a/src/test/java/drinkcounter/model/UserTest.java
+++ b/src/test/java/drinkcounter/model/UserTest.java
@@ -228,7 +228,7 @@ public class UserTest {
     public void drinkXDrinksNMinutesAgo(User user, int drinks, int minutes) {
         for (int i = 0; i < drinks; i++) {
             Drink drink = new Drink();
-            drink.setTimeStamp(new DateTime().minusMinutes(minutes).toDate());
+            drink.setTimeStamp(new DateTime().minusMinutes(minutes).toDate().toInstant());
             user.drink(drink);
         }
     }


### PR DESCRIPTION
Cleans up two Hibernate startup warnings found while checking backend logs:

- **Silence the `createClob()` probe warning.** Railway's production DB (CockroachDB) doesn't implement `Connection.createClob()`, which Hibernate probes at startup and logs noisily even though it's harmless. Force the non-contextual (in-memory) LOB creator instead, since the app has no `@Lob` fields.
- **Migrate `Drink.timeStamp`/`Party.startTime` off deprecated `@Temporal`.** Move both to `java.time.Instant`, pinning `@JdbcTypeCode(SqlTypes.TIMESTAMP)` so the existing `timestamp without time zone` columns and the JSON wire format (`PartyDTO`/`DrinkDTO`) stay unchanged.

## Test plan
- [x] `mvn test` — all unit tests pass
- [x] Full Playwright e2e suite (register/login, party creation, drink logging + promille update) passes
- [x] Verified locally: schema columns unchanged, API JSON shape unchanged before/after (diffed real responses)
