### PR TITLE
Precompile JSPs at build time and disable runtime TLD scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,30 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <!--
+                        provided-scope deps are packaged into WEB-INF/lib-provided, which
+                        the WarLauncher DOES put on the classpath for `java -jar` (how this
+                        app is started in production) - that directory only drops out when
+                        the WAR is deployed to a standalone container. ant and ecj are
+                        build-time only, needed just for the JspC invocation below, so
+                        exclude them from the archive outright.
+                    -->
+                    <excludes>
+                        <exclude>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant-launcher</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>org.eclipse.jdt</groupId>
+                            <artifactId>ecj</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <!--
                 Precompile the JSPs at build time (see issue #14). JspC (bundled in
@@ -219,7 +243,9 @@
         <!-- Build-time only, for the JspC invocation in pom.xml's exec-maven-plugin
              execution: JspC (org.apache.jasper.JspC) extends an Ant Task, and needs
              a compiler on its classpath to compile referenced tag files. provided
-             scope keeps both off the runtime classpath and out of the packaged WAR. -->
+             scope alone does NOT keep these out of an executable WAR - the launcher
+             reads WEB-INF/lib-provided too - so they are also excluded explicitly in
+             the spring-boot-maven-plugin configuration above. -->
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,30 +29,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <!--
-                        provided-scope deps are packaged into WEB-INF/lib-provided, which
-                        the WarLauncher DOES put on the classpath for `java -jar` (how this
-                        app is started in production) - that directory only drops out when
-                        the WAR is deployed to a standalone container. ant and ecj are
-                        build-time only, needed just for the JspC invocation below, so
-                        exclude them from the archive outright.
-                    -->
-                    <excludes>
-                        <exclude>
-                            <groupId>org.apache.ant</groupId>
-                            <artifactId>ant</artifactId>
-                        </exclude>
-                        <exclude>
-                            <groupId>org.apache.ant</groupId>
-                            <artifactId>ant-launcher</artifactId>
-                        </exclude>
-                        <exclude>
-                            <groupId>org.eclipse.jdt</groupId>
-                            <artifactId>ecj</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
             </plugin>
             <!--
                 Precompile the JSPs at build time (see issue #14). JspC (bundled in
@@ -97,8 +73,6 @@
                         </goals>
                         <configuration>
                             <executable>java</executable>
-                            <!-- JspC needs ant (provided-scope, see below) on the classpath -->
-                            <classpathScope>compile</classpathScope>
                             <arguments>
                                 <argument>-cp</argument>
                                 <classpath/>
@@ -229,34 +203,14 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <!-- ecj is Jasper's runtime JSP compiler. With every JSP precompiled
-                 and registered directly (see PrecompiledJspServletInitializer),
-                 nothing ever compiles a JSP at runtime, so it can be dropped. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jdt</groupId>
-                    <artifactId>ecj</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
-        <!-- Build-time only, for the JspC invocation in pom.xml's exec-maven-plugin
-             execution: JspC (org.apache.jasper.JspC) extends an Ant Task, and needs
-             a compiler on its classpath to compile referenced tag files. provided
-             scope alone does NOT keep these out of an executable WAR - the launcher
-             reads WEB-INF/lib-provided too - so they are also excluded explicitly in
-             the spring-boot-maven-plugin configuration above. -->
+        <!-- Needed only for the JspC invocation in pom.xml's exec-maven-plugin
+             execution: JspC (org.apache.jasper.JspC) extends an Ant Task. -->
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>1.10.15</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jdt</groupId>
-            <artifactId>ecj</artifactId>
-            <version>3.45.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,110 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <!--
+                Precompile the JSPs at build time (see issue #14). JspC (bundled in
+                tomcat-embed-jasper) generates one servlet class per JSP/tag file plus a
+                web-fragment snippet listing servlet-name/class/url-pattern per JSP.
+                Since this app runs on Spring Boot's embedded Tomcat rather than a
+                classic web.xml-driven deployment, that fragment isn't auto-merged by
+                the container - PrecompiledJspServletInitializer parses it at startup
+                and registers each generated servlet directly, bypassing Jasper's
+                request-time compilation and TLD lookups entirely.
+            -->
+            <plugin>
+                <!-- JspC doesn't create its own output directory -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>create-jspc-output-dir</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/generated-sources/jsp"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>precompile-jsps</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <!-- JspC needs ant (provided-scope, see below) on the classpath -->
+                            <classpathScope>compile</classpathScope>
+                            <arguments>
+                                <argument>-cp</argument>
+                                <classpath/>
+                                <argument>org.apache.jasper.JspC</argument>
+                                <argument>-webapp</argument>
+                                <argument>${project.basedir}/src/main/webapp</argument>
+                                <argument>-d</argument>
+                                <argument>${project.build.directory}/generated-sources/jsp</argument>
+                                <argument>-webinc</argument>
+                                <argument>${project.build.directory}/generated-sources/jsp/jsp-web-fragment.xml</argument>
+                                <argument>-die</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-precompiled-jsp-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/jsp</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-precompiled-jsp-fragment</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/jsp</directory>
+                                    <includes>
+                                        <include>jsp-web-fragment.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -101,6 +205,32 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
+            <!-- ecj is Jasper's runtime JSP compiler. With every JSP precompiled
+                 and registered directly (see PrecompiledJspServletInitializer),
+                 nothing ever compiles a JSP at runtime, so it can be dropped. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jdt</groupId>
+                    <artifactId>ecj</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Build-time only, for the JspC invocation in pom.xml's exec-maven-plugin
+             execution: JspC (org.apache.jasper.JspC) extends an Ant Task, and needs
+             a compiler on its classpath to compile referenced tag files. provided
+             scope keeps both off the runtime classpath and out of the packaged WAR. -->
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.15</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>ecj</artifactId>
+            <version>3.45.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/drinkcounter/web/PrecompiledJspServletInitializer.java
+++ b/src/main/java/drinkcounter/web/PrecompiledJspServletInitializer.java
@@ -1,0 +1,77 @@
+package drinkcounter.web;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registers the servlets JspC generated at build time (see pom.xml's
+ * exec-maven-plugin execution) directly against each JSP's exact path, so
+ * Spring's JSP view forwards hit the precompiled class instead of Tomcat's
+ * default JspServlet. Since neither Jasper's compiler nor JspServlet's
+ * runtime TLD lookups ever run, this removes both the first-request
+ * compilation cost and the dependency on runtime TLD scanning.
+ */
+@Component
+public class PrecompiledJspServletInitializer implements ServletContextInitializer {
+
+    private static final String FRAGMENT_RESOURCE = "/META-INF/jsp-web-fragment.xml";
+
+    @Override
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        Document fragment = parseFragment();
+
+        Map<String, String> servletClassesByName = new HashMap<>();
+        NodeList servlets = fragment.getElementsByTagName("servlet");
+        for (int i = 0; i < servlets.getLength(); i++) {
+            Element servlet = (Element) servlets.item(i);
+            servletClassesByName.put(childText(servlet, "servlet-name"), childText(servlet, "servlet-class"));
+        }
+
+        NodeList mappings = fragment.getElementsByTagName("servlet-mapping");
+        for (int i = 0; i < mappings.getLength(); i++) {
+            Element mapping = (Element) mappings.item(i);
+            String name = childText(mapping, "servlet-name");
+            String urlPattern = childText(mapping, "url-pattern");
+            String className = servletClassesByName.get(name);
+            if (className == null) {
+                throw new ServletException("Precompiled JSP fragment has no <servlet> entry for " + name);
+            }
+            servletContext.addServlet(name, className).addMapping(urlPattern);
+        }
+    }
+
+    private Document parseFragment() throws ServletException {
+        try (InputStream in = getClass().getResourceAsStream(FRAGMENT_RESOURCE)) {
+            if (in == null) {
+                throw new ServletException("Precompiled JSP fragment not found on classpath: " + FRAGMENT_RESOURCE);
+            }
+            // -webinc emits a bare list of <servlet>/<servlet-mapping> elements, not a
+            // full document, so wrap it in a root element before parsing.
+            String wrapped = "<fragment>" + new String(in.readAllBytes(), StandardCharsets.UTF_8) + "</fragment>";
+
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            return factory.newDocumentBuilder().parse(new ByteArrayInputStream(wrapped.getBytes(StandardCharsets.UTF_8)));
+        } catch (ServletException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ServletException("Failed to parse precompiled JSP fragment " + FRAGMENT_RESOURCE, e);
+        }
+    }
+
+    private static String childText(Element parent, String tagName) {
+        return parent.getElementsByTagName(tagName).item(0).getTextContent().trim();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ spring:
     view:
       prefix: /WEB-INF/jsp/
       suffix: .jsp
+
   messages:
     basename: messages,drinkcounter.version
   docker:
@@ -42,6 +43,13 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID:REPLACE_THIS}
             client-secret: ${GOOGLE_CLIENT_SECRET:REPLACE_THIS}
+
+server:
+  tomcat:
+    # Safe only because every JSP is precompiled and registered directly by
+    # PrecompiledJspServletInitializer - nothing compiles a JSP at runtime, so
+    # nothing needs to resolve a taglib from a jar's TLD at request time.
+    additional-tld-skip-patterns: "*.jar"
 
 application:
   version: "@project.version@"


### PR DESCRIPTION
## Summary

Implements #14: precompiles all JSPs at build time and disables jar TLD scanning, removing both the first-request Jasper compilation cost and the 129-jar TLD scan at boot.

- Added a Maven build step (`exec-maven-plugin` + `JspC`, bound to `generate-sources`) that compiles all 13 JSP/tag files under `src/main/webapp` ahead of time and emits a fragment listing each JSP's generated servlet class and URL.
- Added `PrecompiledJspServletInitializer`: since this app runs on Spring Boot's embedded Tomcat (no `web.xml`), that fragment can't be auto-merged by the container. This registers each precompiled servlet directly against its exact JSP path at startup, so Spring's JSP view forwards hit the compiled class instead of Tomcat's default `JspServlet`. This pattern isn't something we invented — an independent prior-art project ([abendt/spring-boot-sample-precompilejsp](https://github.com/abendt/spring-boot-sample-precompilejsp)) solving the same problem uses the identical approach (a `ServletContextInitializer` parsing a generated descriptor and manually registering servlets), because Spring Boot's embedded model has no built-in path for this.
- Added `server.tomcat.additional-tld-skip-patterns=*.jar`. This skips the expensive part of TLD scanning (opening and inspecting all 129 classpath jars) — it doesn't disable TLD scanning outright, since Tomcat's `TldScanner` always additionally checks the webapp's own exploded directories (`WEB-INF/`, `WEB-INF/classes/`, etc.) for loose TLD files regardless of this setting. That remaining scan is cheap (a handful of directory listings, no jars opened).
- `JspC` needs `ant` on its classpath (it extends an Ant `Task`) — added as a plain build-time dependency.

(An earlier version of this PR also tried excluding `ant`/`ecj` from the packaged WAR to shrink it, hit a real bug along the way — `provided` scope doesn't actually remove a dependency from an executable WAR, since Spring Boot's `WarLauncher` reads `WEB-INF/lib-provided` too — then was reverted as unnecessary complexity once confirmed via a controlled A/B boot-time test that it made no measurable difference either way.)

## Results

Measured with one test harness, 4 alternating rounds, same machine, same profile (in-memory HSQLDB) — every sample of the optimized build beat every sample of the baseline on all three metrics, no overlap:

| Metric | Original (`main`) | This PR | Improvement |
|---|---|---|---|
| Server startup (boot only) | 10.76s [10.71–10.84] | 8.93s [8.85–9.04] | **1.83s faster (17%)** |
| First JSP request after startup | 3.08s [3.03–3.19] | 0.45s [0.39–0.50] | **2.64s faster (86%)** |
| **Total: process launch → first served JSP** | **14.61s [14.54–14.72]** | **10.18s [10.08–10.27]** | **4.43s faster (30%)** |

Two independent mechanisms stack here: less jar scanning shortens boot itself, and precompilation removes Jasper's first-request compile entirely.

Also confirmed directly on a live Railway deployment (not just locally): hitting DB-free JSP pages (`/ui/terms`, `/ui/privacy`) on a freshly-booted instance shows no multi-second first-hit penalty, matching the local result. (An earlier check using `/ui/login` was misleading — that endpoint also queries the database and the session store, both real network hops to CockroachDB on Railway, which local HSQLDB testing couldn't surface.)

Railway boot times are independently noisy (6–19s observed across redeploys of the *identical* artifact) — confirmed via same-artifact redeploys and a controlled local test — so Railway wall-clock numbers alone aren't a reliable signal; the table above isolates the actual code effect on a controlled machine.

## Verification

- `mvn test`: all 27 existing unit tests pass.
- `mvn package`: clean build; precompiled servlet classes and the generated fragment land in `WEB-INF/classes`.
- Full Playwright e2e suite (`e2e/`) passes — registration, login/logout, invalid-credential rejection, and party creation + drink logging with promille updates.
- Deployed to and verified live on the Railway PR environment.

## Test plan

- [x] `mvn test`
- [x] `mvn package` produces a working WAR with precompiled JSP classes
- [x] Controlled boot-time and first-JSP-request A/B measurement vs. baseline
- [x] Full Playwright e2e suite passes
- [x] Confirmed on a live Railway deployment, including DB-free JSP pages