### PR TITLE
Fix AOT training crash on Railway: prod SPRING_DATASOURCE_* env vars leak into the training boot

### DIFF
--- a/scripts/railway-build-aot-cache.sh
+++ b/scripts/railway-build-aot-cache.sh
@@ -55,7 +55,8 @@ done
 
 if [ -z "$STARTED" ]; then
   echo "!! AOT training run did not start within 60s, skipping AOT cache" >&2
-  tail -50 "$TRAIN_LOG" >&2 || true
+  echo "!! full training log follows:" >&2
+  cat "$TRAIN_LOG" >&2 || true
   kill "$TRAIN_PID" 2>/dev/null || true
   wait "$TRAIN_PID" 2>/dev/null || true
   exit 0

--- a/scripts/railway-build-aot-cache.sh
+++ b/scripts/railway-build-aot-cache.sh
@@ -32,7 +32,13 @@ rm -f "$AOT_CACHE" "$TRAIN_LOG"
 
 echo "==> AOT training run"
 set +e
-java -XX:AOTCacheOutput="$AOT_CACHE" \
+# Railway sets SPRING_DATASOURCE_URL/USERNAME/PASSWORD for the real Postgres
+# on this service, and env vars outrank application-aot-train.yml's
+# spring.datasource.*, so left alone they point this HSQLDB-driven boot at
+# the production JDBC URL and it fails to construct a DataSource. Unset them
+# for this subprocess so the profile's own datasource config applies.
+env -u SPRING_DATASOURCE_URL -u SPRING_DATASOURCE_USERNAME -u SPRING_DATASOURCE_PASSWORD \
+  java -XX:AOTCacheOutput="$AOT_CACHE" \
   -jar "$WAR" \
   --spring.profiles.active=aot-train \
   --server.port="$TRAIN_PORT" \

--- a/src/main/resources/application-aot-train.yml
+++ b/src/main/resources/application-aot-train.yml
@@ -11,3 +11,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+  session:
+    # The base config selects the JDBC session store, which on context
+    # startup probes the DB platform via PlatformPlaceholderDatabaseDriverResolver
+    # to pick a schema-*.sql script. On Railway that probe has twice crashed
+    # the training run before it reaches "Started RyyppyApplication" (see
+    # scripts/railway-build-aot-cache.sh), so the cache ends up built from a
+    # truncated boot. The training run never exercises persisted sessions,
+    # so fall back to plain in-memory servlet sessions here instead of
+    # chasing why the probe fails on Railway's build container.
+    store-type: none

--- a/src/main/resources/application-aot-train.yml
+++ b/src/main/resources/application-aot-train.yml
@@ -1,7 +1,11 @@
 # Used only to produce the JDK 25 AOT cache during the build (see
-# scripts/railway-build-aot-cache.sh). Boots against an in-memory HSQLDB
-# instead of the real Postgres so the training run has no external
-# dependencies and never touches production data.
+# scripts/railway-build-aot-cache.sh, which also unsets SPRING_DATASOURCE_*
+# for this profile's boot - Railway injects those as env vars for the real
+# Postgres, and an env var outranks this file's spring.datasource.url,
+# which broke the training run against the driver-class-name below).
+# Boots against an in-memory HSQLDB instead of the real Postgres so the
+# training run has no external dependencies and never touches production
+# data.
 spring:
   datasource:
     url: jdbc:hsqldb:mem:aottrain
@@ -11,13 +15,3 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-  session:
-    # The base config selects the JDBC session store, which on context
-    # startup probes the DB platform via PlatformPlaceholderDatabaseDriverResolver
-    # to pick a schema-*.sql script. On Railway that probe has twice crashed
-    # the training run before it reaches "Started RyyppyApplication" (see
-    # scripts/railway-build-aot-cache.sh), so the cache ends up built from a
-    # truncated boot. The training run never exercises persisted sessions,
-    # so fall back to plain in-memory servlet sessions here instead of
-    # chasing why the probe fails on Railway's build container.
-    store-type: none


### PR DESCRIPTION
## Summary

Railway's AOT training run (`scripts/railway-build-aot-cache.sh`) has crashed on every attempted build. Its `tail -50` failure log truncated the real error, hiding the actual cause: Railway sets `SPRING_DATASOURCE_URL`/`USERNAME`/`PASSWORD` env vars for the real CockroachDB, which outrank `application-aot-train.yml`'s `spring.datasource.url` in Spring's property precedence — so the training boot ended up with the HSQLDB driver class paired against the production Postgres URL, which HikariCP rejects outright.

**Fix:**
- `scripts/railway-build-aot-cache.sh`: unset those three env vars for the training subprocess only, so the profile's own HSQLDB config applies. The real deploy command is untouched.
- `scripts/railway-build-aot-cache.sh`: widen the failure-path log dump from `tail -50` to the full log, so a future failure isn't hidden.

**Verified:**
- Reproduced the exact Railway crash locally by exporting the same env vars, then confirmed the fix resolves it.
- Railway PR build now completes end-to-end: training reaches `Started RyyppyApplication`, warm-up requests succeed, a full (135M) AOT cache is produced, and the deployed app boots in 5.8s against production data.
- Isolated the cache's actual effect locally (same jar, with/without `-XX:AOTCache`): ~9.3s cold vs ~5.8s warm, a ~37% reduction — consistent with the original ~30% target this feature was built for but never achieved due to the bug above.
