### PR TITLE
Run from the extracted WAR layout instead of the nested WAR

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,6 +5,6 @@
     "buildCommand": "bash scripts/railway-build-aot-cache.sh"
   },
   "deploy": {
-    "startCommand": "java -Dserver.port=$PORT $JAVA_OPTS -jar target/ryyppynet.war"
+    "startCommand": "java -Dserver.port=$PORT $JAVA_OPTS -jar target/extracted/ryyppynet.war"
   }
 }

--- a/scripts/railway-build-aot-cache.sh
+++ b/scripts/railway-build-aot-cache.sh
@@ -19,12 +19,27 @@ echo "==> mvn package"
 mvn -B -DskipTests package
 
 WAR=target/ryyppynet.war
+EXTRACTED_DIR=target/extracted
+EXTRACTED_WAR="$EXTRACTED_DIR/ryyppynet.war"
 AOT_CACHE=target/app.aot
 TRAIN_LOG=target/aot-train.log
 TRAIN_PORT=8080
 
 if [ ! -f "$WAR" ]; then
   echo "!! $WAR not found after mvn package, aborting" >&2
+  exit 1
+fi
+
+# Extract the WAR into a thin executable WAR plus a flat lib/ directory
+# (see issue #15). The JDK AOT cache is layout-specific, so it has to be
+# trained against this extracted layout rather than the nested-jar WAR -
+# that's also what the production start command now launches.
+echo "==> extracting WAR"
+rm -rf "$EXTRACTED_DIR"
+java -Djarmode=tools -jar "$WAR" extract --destination "$EXTRACTED_DIR"
+
+if [ ! -f "$EXTRACTED_WAR" ]; then
+  echo "!! $EXTRACTED_WAR not found after extraction, aborting" >&2
   exit 1
 fi
 
@@ -39,7 +54,7 @@ set +e
 # for this subprocess so the profile's own datasource config applies.
 env -u SPRING_DATASOURCE_URL -u SPRING_DATASOURCE_USERNAME -u SPRING_DATASOURCE_PASSWORD \
   java -XX:AOTCacheOutput="$AOT_CACHE" \
-  -jar "$WAR" \
+  -jar "$EXTRACTED_WAR" \
   --spring.profiles.active=aot-train \
   --server.port="$TRAIN_PORT" \
   > "$TRAIN_LOG" 2>&1 &


### PR DESCRIPTION
## Summary

Extract the WAR at build time and start the extracted layout instead of the nested WAR, per #15. The JDK AOT cache is far more effective against a flat classpath of real jar files than against Spring Boot's nested-jar classloader.

- `scripts/railway-build-aot-cache.sh`: after `mvn package`, run `java -Djarmode=tools -jar target/ryyppynet.war extract --destination target/extracted`, producing a thin executable WAR plus a flat `lib/` directory. The AOT training run now boots against that extracted WAR instead of the nested one, since the AOT cache is layout-specific.
- `railway.json`: `deploy.startCommand` now launches `target/extracted/ryyppynet.war`.

This was previously blocked by #14 (JSP TLD resolution breaking under the extracted layout); that's landed, so the runtime TLD lookup issue no longer applies.

## Verification

- `bash scripts/railway-build-aot-cache.sh` runs clean end-to-end and produces `target/app.aot` trained against the extracted layout.
- Booted the app with the exact production start command (`java -Dserver.port=8080 -XX:AOTCache=target/app.aot -jar target/extracted/ryyppynet.war`) against a real local Postgres: **`Started RyyppyApplication in 2.963 seconds`**, in line with the ~2.8s figure from #15 (plus real DB connection time, vs. the in-memory HSQLDB `aot-train` profile the issue measured against).
- Ran the full Playwright suite (`e2e/`) against that running instance — registration, login/logout, invalid-credentials rejection, and party creation/drink logging with promille updates all pass, confirming JSP rendering and the AngularJS/REST stack work correctly from the extracted layout:
  ```
  4 passed (2.3m)
  ```

Closes #15.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg4ibZ3m6N2eoWbXVFKuV2)_