### PR TITLE
Speed up e2e test suite (133s -> ~11s)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,14 +9,17 @@ export default defineConfig({
   // tests are independent and safe to run concurrently against the same
   // server/DB.
   fullyParallel: true,
-  workers: 4,
+  // 2, not 4: registerUser() fills the signup form via fill(), which sets
+  // values without firing keyup, so the checkEmail AJAX callback that
+  // re-enables the submit button can race a not-yet-filled weight field.
+  // Higher concurrency makes that race easier to hit. Follow-up: fix
+  // registerUser() to drive the form with real keystrokes so it can't race,
+  // then this can go back up.
+  workers: 2,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
   timeout: 30_000,
-  // The dashboard fires several sequential AJAX calls (profile, parties,
-  // drink-history, templates) before it's done rendering; the default 5s
-  // expect() timeout is too tight for that under sandboxed/CI network conditions.
-  expect: { timeout: 15_000 },
+  expect: { timeout: 5_000 },
 
   use: {
     baseURL: BASE_URL,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -5,8 +5,11 @@ const BASE_URL = process.env.BASE_URL ?? `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: false,
-  workers: 1,
+  // Each test registers its own uniquely-emailed user (see helpers.ts), so
+  // tests are independent and safe to run concurrently against the same
+  // server/DB.
+  fullyParallel: true,
+  workers: 4,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
   timeout: 30_000,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,13 +9,7 @@ export default defineConfig({
   // tests are independent and safe to run concurrently against the same
   // server/DB.
   fullyParallel: true,
-  // 2, not 4: registerUser() fills the signup form via fill(), which sets
-  // values without firing keyup, so the checkEmail AJAX callback that
-  // re-enables the submit button can race a not-yet-filled weight field.
-  // Higher concurrency makes that race easier to hit. Follow-up: fix
-  // registerUser() to drive the form with real keystrokes so it can't race,
-  // then this can go back up.
-  workers: 2,
+  workers: 4,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',
   timeout: 30_000,

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -21,10 +21,16 @@ export function makeTestUser(label: string): TestUser {
 /** Registers a new user via /ui/newuser and waits until the dashboard has loaded. */
 export async function registerUser(page: Page, user: TestUser): Promise<void> {
   await page.goto('/ui/newuser', { waitUntil: 'domcontentloaded' });
-  await page.fill('#drinkerName', user.name);
-  await page.fill('#email', user.email);
+  // The submit button starts disabled and is only re-enabled by the page's own
+  // keyup-driven validation (checkDrinkerFields/checkEmail in drinkerchecks.js).
+  // fill() sets values without firing keyup, so the async checkEmail response
+  // can race a not-yet-filled weight field and leave the button stuck disabled
+  // with nothing left to re-check it. pressSequentially() types real keystrokes,
+  // like a real user, so the page's own revalidation can't be raced.
+  await page.locator('#drinkerName').pressSequentially(user.name);
+  await page.locator('#email').pressSequentially(user.email);
   await page.selectOption('#sex', 'MALE');
-  await page.fill('#drinkerWeight', user.weight);
+  await page.locator('#drinkerWeight').pressSequentially(user.weight);
   await page.fill('#password', user.password);
   await page.click('#submitButton');
 

--- a/e2e/tests/party-and-drinking.spec.ts
+++ b/e2e/tests/party-and-drinking.spec.ts
@@ -2,12 +2,6 @@ import { test, expect } from '@playwright/test';
 import { makeTestUser, registerUser, createParty } from './helpers';
 
 test('a user can create a party, appear as a participant, and logging a drink updates their promille level', async ({ page }) => {
-  // Registration alone takes ~25-30s to fully render in this sandboxed
-  // environment, and this test also creates a party and waits through the
-  // drink's 5s "undo" countdown afterward, so the default 30s budget
-  // doesn't leave enough room for the whole sequence.
-  test.setTimeout(60_000);
-
   const user = makeTestUser('party');
   await registerUser(page, user);
 

--- a/e2e/tests/registration-login.spec.ts
+++ b/e2e/tests/registration-login.spec.ts
@@ -11,11 +11,6 @@ test('a new user can register and lands on their dashboard', async ({ page }) =>
 });
 
 test('a registered user can log out and log back in', async ({ page }) => {
-  // This test does two full dashboard loads (register, then login), and each
-  // one alone takes ~25-30s in a sandboxed/headless environment, so the
-  // default per-test timeout doesn't leave enough room for both.
-  test.setTimeout(60_000);
-
   const user = makeTestUser('relogin');
   await registerUser(page, user);
 

--- a/src/main/resources/public/app/index.html
+++ b/src/main/resources/public/app/index.html
@@ -9,7 +9,10 @@
     <link rel="stylesheet" href="css/jquery.pnotify.default.css"/>
     <link rel="stylesheet" href="css/app.css"/>
 
-    <link href='https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <!-- media="print" + onload swap keeps this from blocking the synchronous
+         <script> tags below on a slow/unreachable Google Fonts request. -->
+    <link href='https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext' rel='stylesheet' type='text/css' media="print" onload="this.media='all'">
+    <noscript><link href='https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext' rel='stylesheet' type='text/css'></noscript>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -9,7 +9,8 @@
         <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+        <noscript><link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet"></noscript>
 
         <script type="text/javascript">
             function manualLogin() {

--- a/src/main/webapp/WEB-INF/tags/master.tag
+++ b/src/main/webapp/WEB-INF/tags/master.tag
@@ -20,7 +20,13 @@
         <script type="text/javascript" src="/static/js/jquery.js"></script>
         <script type="text/javascript" src="/static/js/jquery.tooltip.min.js"></script>
         <script src="https://accounts.google.com/gsi/client" async defer></script>
-        <link href="https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext" rel="stylesheet" type="text/css" />
+        <%-- Loaded non-render-blocking: a pending <link rel="stylesheet"> in <head>
+             delays every synchronous <script> that follows it (and the scripts
+             customHead adds), so a slow/unreachable Google Fonts request would
+             otherwise stall the whole page. media="print" makes the browser fetch
+             it without waiting on it, then the onload swap applies it once ready. --%>
+        <link href="https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext" rel="stylesheet" type="text/css" media="print" onload="this.media='all'" />
+        <noscript><link href="https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext" rel="stylesheet" type="text/css" /></noscript>
 
         <jsp:invoke fragment="customHead" />
     </head>


### PR DESCRIPTION
## Summary

Investigated why the Playwright e2e suite was slow (133s serial) and fixed it, measuring wall-clock time and re-validating with repeated runs at each step.

- **Stop the Google Fonts stylesheet from blocking page render** (`master.tag`, `login.jsp`, `app/index.html`): each loaded a Google Fonts `<link rel="stylesheet">` synchronously in `<head>`. Per spec, a pending stylesheet blocks every subsequent synchronous `<script>` in the document — a network trace showed this stalling `DOMContentLoaded` for ~13s whenever the request to Google's CDN was slow, which stalled the Angular app's entire script bootstrap on every page load. Switched to the standard non-blocking pattern (`media="print"` + `onload` swap, with a `<noscript>` fallback). This is a real production perf fix, not just a test-environment workaround.
- **Run e2e tests in parallel** (`e2e/playwright.config.ts`): `fullyParallel: true, workers: 4`. Tests are independent (each registers its own uniquely-emailed user), so this is safe.
- **Fixed a real race condition** in `registerUser()`: the signup button is only re-enabled by the page's own keyup-driven validation. `fill()` sets field values without firing `keyup`, so the async `checkEmail` response could arrive before the weight field was filled, leaving the button stuck disabled with nothing left to re-check it — occasionally under parallel load. Switched to `pressSequentially()`, which types real keystrokes and lets the page's existing validation do its job instead of racing it. Verified with an instrumented repro: 6/12 failures with `fill()` at `workers: 4`, 0/12 with `pressSequentially()`.
- Removed two `test.setTimeout(60_000)` overrides and tightened `expect.timeout` back to the 5s default — both existed to compensate for the slow page loads the font fix eliminates.

## Measurements

| Stage | Total wall time (4 tests) |
|---|---|
| Baseline (serial, warm server) | 133s |
| After font fix (still serial) | 28s |
| After parallel workers + race fix | ~11-13s, consistently across 12+ runs |

## Test plan

- [x] Full e2e suite green after each change, measured individually
- [x] 12 consecutive full-suite runs at `workers: 4` with the final code — no flakiness
- [x] Instrumented standalone repro isolating the `registerUser()` race, confirming both the failure and the fix
- [x] Checked app logs for errors under concurrent test load — none
- [x] `mvn -DskipTests compile` succeeds after the JSP/HTML changes
