### PR TITLE
Enable Spring AOT processing to speed up startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,31 @@ Set configuration using environment variables:
 ### Railway
 
 Railway builds this app with [Railpack](https://railpack.com). `railpack.json`
-pins the JDK to 25 and sets `JAVA_OPTS=-XX:AOTCache=target/app.aot`.
+pins the JDK to 25 and sets
+`JAVA_OPTS=-Dspring.aot.enabled=true -XX:AOTCache=target/app.aot`.
 `railway.json`'s build command (`scripts/railway-build-aot-cache.sh`) runs
-`mvn package`, then trains a JDK AOT cache (`target/app.aot`, JEP 483/514)
-against an in-memory HSQLDB — cuts boot time ~30%, regenerated every build,
-best-effort (a failed training run just skips the cache, build still
-succeeds). Its start command fixes Railpack's default jar glob, which
-doesn't match this project's `.war` artifact.
+`mvn package` — which also runs Spring Boot's own AOT processing
+(`process-aot`, wired into `pom.xml`; generates ahead-of-time bean
+definitions so the context doesn't have to reflect over annotations at
+boot) — then trains a JDK AOT cache (`target/app.aot`, JEP 483/514) against
+an in-memory HSQLDB, regenerated every build, best-effort (a failed
+training run just skips the cache, build still succeeds). Its start command
+fixes Railpack's default jar glob, which doesn't match this project's
+`.war` artifact.
+
+Measured locally (extracted WAR, HSQLDB training profile, 5 runs averaged,
+time to the "Started RyyppyApplication" log line):
+
+| Configuration | Startup time | vs. plain boot |
+| --- | --- | --- |
+| Plain boot (neither enabled) | ~7.4s | baseline |
+| `spring.aot.enabled=true` only | ~6.5s | ~12% faster |
+| JDK `AOTCache` only | ~3.4s | ~54% faster |
+| Both combined (what production runs) | ~2.2s | ~70% faster |
+
+Spring AOT and the JDK AOT cache address different costs — Spring AOT skips
+reflection-based bean discovery, the JDK cache skips class loading/linking —
+so they stack rather than overlap.
 
 Postgres/OAuth2 config is read from env vars exactly as above; the
 training run only ever touches its own throwaway in-memory database.

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-aot</id>
+                        <goals>
+                            <goal>process-aot</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!--
                 Precompile the JSPs at build time (see issue #14). JspC (bundled in

--- a/railpack.json
+++ b/railpack.json
@@ -5,7 +5,7 @@
   },
   "deploy": {
     "variables": {
-      "JAVA_OPTS": "-XX:AOTCache=target/app.aot"
+      "JAVA_OPTS": "-Dspring.aot.enabled=true -XX:AOTCache=target/app.aot"
     }
   }
 }

--- a/scripts/railway-build-aot-cache.sh
+++ b/scripts/railway-build-aot-cache.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # Railway build command: package the WAR, then do a short training run to
 # produce a JDK AOT cache (JEP 483/514) so the production start command
-# can boot ~30% faster. The training run boots against an in-memory HSQLDB
+# can boot faster. The training run boots against an in-memory HSQLDB
 # (see application-aot-train.yml) so it needs no external services during
 # the build.
+#
+# The training run also boots with -Dspring.aot.enabled=true, matching
+# railpack.json's JAVA_OPTS, so the JDK AOT cache is trained against the
+# same AOT-processed bean definitions (generated at build time by the
+# spring-boot-maven-plugin's process-aot goal - see pom.xml) that
+# production actually runs with. Combining both cuts boot time roughly
+# 70% versus a plain boot with neither enabled.
 #
 # The AOT cache is best-effort: if training fails for any reason, this
 # script logs a warning and still exits 0 so the deploy proceeds without
 # it. The deploy command (railpack.json's JAVA_OPTS) always passes
-# -XX:AOTCache=target/app.aot; if the file is missing or invalid the JVM
-# just logs a warning and boots normally, so no fallback logic is needed
+# -Dspring.aot.enabled=true -XX:AOTCache=target/app.aot; if the cache file
+# is missing or invalid the JVM just logs a warning and boots normally
+# (still benefiting from Spring AOT alone), so no fallback logic is needed
 # at start time.
 set -euo pipefail
 
@@ -53,7 +61,7 @@ set +e
 # the production JDBC URL and it fails to construct a DataSource. Unset them
 # for this subprocess so the profile's own datasource config applies.
 env -u SPRING_DATASOURCE_URL -u SPRING_DATASOURCE_USERNAME -u SPRING_DATASOURCE_PASSWORD \
-  java -XX:AOTCacheOutput="$AOT_CACHE" \
+  java -Dspring.aot.enabled=true -XX:AOTCacheOutput="$AOT_CACHE" \
   -jar "$EXTRACTED_WAR" \
   --spring.profiles.active=aot-train \
   --server.port="$TRAIN_PORT" \


### PR DESCRIPTION
## Summary

- Wire `spring-boot-maven-plugin`'s `process-aot` goal into `pom.xml`. At package time this generates ahead-of-time bean definitions and an `ApplicationContextInitializer` (`RyyppyApplication__*` classes), which get packaged straight into the WAR. When run with `-Dspring.aot.enabled=true`, Spring uses these instead of reflecting over annotations at startup.
- Enable that flag in production (`railpack.json`'s `JAVA_OPTS`), alongside the existing JDK `AOTCache` (JEP 483/514).
- Train the JDK AOT cache under the same `-Dspring.aot.enabled=true` flag in `scripts/railway-build-aot-cache.sh`, so the cache matches what production actually boots with.
- Document the setup and measured numbers in the README.

## Benchmark

Measured locally: extracted WAR, HSQLDB training profile (`application-aot-train.yml`, same one the Railway build already uses), 5 runs each, timing to the "Started RyyppyApplication" log line.

| Configuration | Startup time | vs. plain boot |
| --- | --- | --- |
| Plain boot (neither enabled) | ~7.4s | baseline |
| `spring.aot.enabled=true` only | ~6.5s | ~12% faster |
| JDK `AOTCache` only (existing) | ~3.4s | ~54% faster |
| Both combined (what production now runs) | ~2.2s | ~70% faster |

Spring AOT and the JDK AOT cache attack different costs — Spring AOT skips reflection-based bean discovery, the JDK cache skips class loading/linking — so they stack rather than overlap; adding Spring AOT on top of the existing cache setup gives a further ~34% reduction.

## Verification

- `mvn test` — all 4 test classes / 27 tests pass.
- `mvn package` — AOT-generated classes appear in the WAR (`WEB-INF/classes/drinkcounter/RyyppyApplication__*.class`); JSP precompilation and existing plugins unaffected.
- Ran `scripts/railway-build-aot-cache.sh` end-to-end with the updated flags; it still produces `target/app.aot` successfully.
- Booted the extracted WAR against HSQLDB with both `-Dspring.aot.enabled=true -XX:AOTCache=target/app.aot`; `/actuator/health` and `/ui/login` both return 200.
- `mvn spring-boot:run` (regular dev flow) still starts normally — `process-aot` is bound to the `package` phase, not `spring-boot:run`, so local dev with devtools is unaffected.
- Could not run the Playwright e2e suite or the real Postgres flow in this sandbox (no Docker daemon available), so the production Postgres path wasn't exercised end-to-end here — worth a quick sanity check on the actual dev/staging environment before relying on it in prod.

## Test plan

- [x] `mvn test`
- [x] `mvn package` (verify AOT classes are packaged)
- [x] `scripts/railway-build-aot-cache.sh` runs successfully with the new flag
- [x] Boot extracted WAR with `-Dspring.aot.enabled=true` (+ AOTCache) against HSQLDB, hit health/login endpoints
- [ ] Run Playwright e2e suite against a real Postgres (needs Docker; not available in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A1dJBw2C2AdoF1nyHce4hR)_