### PR TITLE
Add concurrency control to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Unit tests


### PR DESCRIPTION
## Summary
Adds concurrency configuration to the GitHub Actions CI workflow to cancel in-progress runs when a new workflow is triggered on the same branch.

## Changes
- Added `concurrency` block to `.github/workflows/ci.yml` that groups workflow runs by workflow name and git ref
- Enables `cancel-in-progress: true` to automatically cancel previous runs when a new commit is pushed to the same branch

## Details
This prevents resource waste and reduces CI queue times by ensuring only the latest workflow run for a given branch executes. When a developer pushes multiple commits in quick succession, earlier CI runs are cancelled in favor of the most recent one.

https://claude.ai/code/session_01VvtZzutwDK7to2x5kMJeFJ