### PR TITLE
Enable build-time Hibernate bytecode enhancement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,29 @@
                 </executions>
             </plugin>
             <!--
+                Build-time Hibernate bytecode enhancement. Without this, Hibernate
+                generates lazy-loading/dirty-checking bytecode for each @Entity at
+                startup via ByteBuddy; this plugin bakes that enhancement into the
+                compiled classes instead, so startup just loads them.
+            -->
+            <plugin>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-maven-plugin</artifactId>
+                <version>7.4.5.Final</version>
+                <executions>
+                    <execution>
+                        <id>enhance</id>
+                        <configuration>
+                            <enableLazyInitialization>true</enableLazyInitialization>
+                            <enableDirtyTracking>true</enableDirtyTracking>
+                        </configuration>
+                        <goals>
+                            <goal>enhance</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
                 Precompile the JSPs at build time (see issue #14). JspC (bundled in
                 tomcat-embed-jasper) generates one servlet class per JSP/tag file plus a
                 web-fragment snippet listing servlet-name/class/url-pattern per JSP.


### PR DESCRIPTION
## Summary

- Adds the `hibernate-maven-plugin` (7.4.5.Final, matching the resolved `hibernate-core` version) bound to the `enhance` goal, with `enableLazyInitialization` and `enableDirtyTracking` turned on.
- Without this, Hibernate generates the lazy-loading/dirty-checking bytecode for each `@Entity` (`Drink`, `User`, `Party`) at runtime via ByteBuddy on every boot. The plugin bakes that enhancement into the compiled classes at build time instead, so startup just loads already-enhanced classes rather than generating them.
- This is separate from (and composes with) the existing Spring AOT + JDK AOT cache setup (`railway-build-aot-cache.sh`): the AOT cache training run will now also capture the enhanced-class loading path.
- Note: `org.hibernate.orm.tooling:hibernate-enhance-maven-plugin` (the pre-7.0 coordinates) is no longer published past `7.0.0.Beta1`; Hibernate 7 replaced it with `org.hibernate.orm:hibernate-maven-plugin`.

## Verification

- `mvn test` passes.
- `mvn package` (skipping tests) builds successfully; confirmed via `javap` that `Drink`, `User`, and `Party` now implement `PersistentAttributeInterceptable`/`SelfDirtinessTracker` and carry the `$$_hibernate_*` enhanced accessors.
- Local plain-boot timing (no JDK AOT cache, not representative of production) was inconclusive/within noise (~6.4s baseline vs ~6.2s enhanced over 3 runs each) — the real signal is the Railway PR-environment deploy log, since that's where the trained AOT cache and enhanced classes combine.

## Test plan

- [x] `mvn test`
- [x] `mvn package` + inspect enhanced entity classes
- [ ] Compare Railway PR-environment deploy logs (boot time) against a recent `main` deploy once this PR's environment finishes building

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZNS1GdejCTfJcw2fC4ETR)_