### PR TITLE
Add npm and github-actions ecosystems to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- Dependabot was only configured for `maven` at the repo root, leaving the `e2e/` npm project (Playwright) and the GitHub Actions used in `.github/workflows/ci.yml` unmonitored.
- Added `npm` ecosystem scoped to `/e2e` and `github-actions` ecosystem scoped to `/`, both on a daily schedule to match the existing Maven config.

## Test plan
- [x] Validated `.github/dependabot.yml` structure against the existing entries and Dependabot's documented `package-ecosystem` values (`npm`, `github-actions`).
- Config changes only; no application code affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DcB6rs2jBhNbdACi1WNLVm)_