### PR TITLE
Remove dead OpenID 2.0 auth scaffolding

### DIFF
--- a/src/main/java/drinkcounter/authentication/UserDetailsServiceImpl.java
+++ b/src/main/java/drinkcounter/authentication/UserDetailsServiceImpl.java
@@ -27,13 +27,10 @@ public class UserDetailsServiceImpl implements UserDetailsService{
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
-        User user = userService.getUserByEmail(username);
-        if (user == null) {
-            user = userService.getUserByOpenId(username);
-        }
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException, DataAccessException {
+        User user = userService.getUserByEmail(email);
         if(user == null){
-            throw new UsernameNotFoundException("User with username "+username+" doesn't exist");
+            throw new UsernameNotFoundException("User with username "+email+" doesn't exist");
         }
         return new DrinkcounterUserDetails(user.getEmail(),
                 user.getPassword(),

--- a/src/main/java/drinkcounter/web/controllers/ui/AuthenticationController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/AuthenticationController.java
@@ -25,8 +25,6 @@ import static drinkcounter.web.controllers.DefaultController.REDIRECT_TO_FRONTPA
 @RequestMapping("ui")
 public class AuthenticationController {
     
-    public static final String OPENID = "openId";
-    public static final String DISCOVERYINFORMATION = "discoveryInformation";
     public static final String TIMEZONEOFFSET = "timeZoneOffset";
 
     @Autowired private DrinkCounterService drinkCounterService;

--- a/src/main/java/drinkcounter/web/controllers/ui/UserController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/UserController.java
@@ -41,9 +41,6 @@ import static drinkcounter.web.controllers.DefaultController.REDIRECT_TO_FRONTPA
 @Controller
 @RequestMapping("ui")
 public class UserController {
-    public static final String OPENID_CREDENTIAL_KEY = "USER_OPENID_CREDENTIAL";
-    
-    
     @Autowired private DrinkCounterService drinkCounterService;
     @Autowired private UserService userService;
 

--- a/src/main/java/drinkcounter/web/controllers/ui/UserController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/UserController.java
@@ -88,8 +88,6 @@ public class UserController {
         user.setPassword(passwordEncoder.encode(password));
         user.setAuthMethod(User.AuthMethod.PASSWORD);
 
-        Authentication authToken = (Authentication) session.getAttribute(AuthenticationController.OPENID);
-
         userService.addUser(user);
         authenticate(user, request, response);
 
@@ -97,13 +95,8 @@ public class UserController {
     }
 
     private void authenticate(User user, HttpServletRequest request, HttpServletResponse response){
-        String username = user.getAuthMethod() == User.AuthMethod.PASSWORD ? user.getEmail() : user.getOpenId();
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-        Authentication authentication = null;
-        switch(user.getAuthMethod()){
-            case PASSWORD:
-                authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        }
+        UserDetails userDetails = userDetailsService.loadUserByUsername(user.getEmail());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(authentication);

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -12,17 +12,6 @@
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
         <noscript><link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet"></noscript>
 
-        <script type="text/javascript">
-            function manualLogin() {
-                $("#manualLogin").show(300);
-                $("#openId").focus();
-            }
-
-            function login(openId){
-                $('#openId').val(openId);
-                $('#form').submit();
-            }
-        </script>
         <script type="text/javascript" src="/static/js/login.js"></script>
     </jsp:attribute>
     


### PR DESCRIPTION
Google OAuth2/OIDC login is fully self-contained via
CustomOAuth2UserService and never touches UserController.authenticate()
or UserDetailsServiceImpl, so the old OpenID 2.0 branches were dead and
misleading:

- UserController.authenticate() no longer branches on AuthMethod; it's
  only ever called for PASSWORD users, so the incomplete switch (which
  left authentication null for any other case) is gone.
- Removed the unused authToken local in addUser().
- UserDetailsServiceImpl.loadUserByUsername() now looks up by email
  only, since that's the only value it's ever called with.
- Removed the unused OPENID/DISCOVERYINFORMATION constants from
  AuthenticationController.
- Removed login.jsp's dead manualLogin()/login() JS, which referenced
  an #openId input and #form that no longer exist in the page.

Fixes #9