### PR TITLE
Remove dead OpenID/Facebook/Google+ login-era cruft

### DIFF
--- a/src/main/java/drinkcounter/model/User.java
+++ b/src/main/java/drinkcounter/model/User.java
@@ -46,7 +46,7 @@ public class User extends AbstractEntity{
         }
     }
     public enum AuthMethod {
-        OPENID, FACEBOOK, PASSWORD
+        OPENID, PASSWORD
     }
 
     private String email;

--- a/src/main/java/drinkcounter/web/controllers/api/APIController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/APIController.java
@@ -244,7 +244,6 @@ public class APIController {
         int pid = Integer.parseInt(partyId);
         int uid = Integer.parseInt(userId);
         authenticationChecks.checkRightsForParty(pid);
-//        authenticationChecks.checkHighLevelRightsToUser(openId, uid); // TODO privacy
         drinkCounterService.linkUserToParty(uid, pid);
         return "";
     }

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -23,10 +23,7 @@ error.to_frontpage = to frontpage
 error.try_again = and try again.
 
 # Messages in login.jsp
-login.login_title = Log in with OpenID
-login.login_manual = Manual OpenID log in
-login.security_info = By logging in with above services you will give your username and password only to the service provider eg. Google. We do not get access to your login information.
-login.more_security_info = You can read more information from <a href="http://en.wikipedia.org/wiki/OpenID">here</a>.
+login.login_title = Log in
 
 login.already_n_drinks = {0} drinks served!
 
@@ -39,9 +36,7 @@ login.info.youtube = on YouTube!
 # Messages in loginerror.jsp
 loginerror.title = Error!
 loginerror.reasons = Possible causes:
-loginerror.list.bad_openid = you mispelled your OpedID
-loginerror.list.no_2_0_standard = your OpenID provider doesn't follow OpenID 2.0 standard
-loginerror.list.login_failed = you screwed up with your OpenID provider
+loginerror.list.login_failed = you mistyped your username or password, or something went wrong with Google login
 loginerror.list.bug = there's a bug
 loginerror.list.tell_us = tell us about it
 loginerror.list.you_fucked_up = you screwed up something else

--- a/src/main/resources/messages_fi.properties
+++ b/src/main/resources/messages_fi.properties
@@ -24,9 +24,6 @@ error.try_again = ja kokeile uudelleen.
 
 # Messages in login.jsp
 login.login_title = Kirjaudu sis\u00e4\u00e4n
-login.login_manual = Manuaalinen OpenID-kirjautuminen
-login.security_info = Kirjautumalla yll\u00e4olevilla palveluilla annatte k\u00e4ytt\u00e4j\u00e4tunnuksenne vain palveluntarjoajalle kuten Googlelle. Me emme saa tietoomme k\u00e4ytt\u00e4j\u00e4tunnuksiasi.
-login.more_security_info = Voit lukea lis\u00e4tietoja <a href="http://fi.wikipedia.org/wiki/OpenID">t\u00e4\u00e4lt\u00e4</a>.
 
 login.already_n_drinks = Jo {0} juomaa juotu!
 
@@ -39,9 +36,7 @@ login.info.youtube = YouTubesta!
 # Messages in loginerror.jsp
 loginerror.title = Tapahtui virhe!
 loginerror.reasons = Mahdollisia syit\u00e4:
-loginerror.list.bad_openid = kirjoitit OpenId-tunnuksesi v\u00e4\u00e4rin
-loginerror.list.no_2_0_standard = OpenID-palveluntarjoajasi ei ole OpenID 2.0 -standardin mukainen
-loginerror.list.login_failed = tyrit kirjautumisesi OpenID-palveluntarjoajasi kanssa
+loginerror.list.login_failed = kirjoitit k\u00e4ytt\u00e4j\u00e4tunnuksesi tai salasanasi v\u00e4\u00e4rin, tai Google-kirjautumisessa meni jotain pieleen
 loginerror.list.bug = j\u00e4rjestelm\u00e4ss\u00e4 on bugi, 
 loginerror.list.tell_us = kerro siit\u00e4 meille
 loginerror.list.you_fucked_up = t\u00f6h\u00f6tit jotain muuta

--- a/src/main/resources/public/static/css/login.css
+++ b/src/main/resources/public/static/css/login.css
@@ -39,16 +39,6 @@ body {
     text-decoration: none;
 }
 
-#apNappula {
-    height:67px;
-    z-index:2;
-}
-
-#apNappula img {
-    float: right;
-    border: none;
-}
-
 #logoContainer {
     margin-top: 10px;
     margin-left: auto;
@@ -63,13 +53,6 @@ p.totalDrinkCount {
 
 #logo {
     width: 100%;
-}
-
-#openId {
-    padding: 6px;
-    width:300px;
-    color: #333;
-    font-size: 16px;
 }
 
 table {

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -12,17 +12,6 @@
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
         <noscript><link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet"></noscript>
 
-        <script type="text/javascript">
-            function manualLogin() {
-                $("#manualLogin").show(300);
-                $("#openId").focus();
-            }
-
-            function login(openId){
-                $('#openId').val(openId);
-                $('#form').submit();
-            }
-        </script>
         <script type="text/javascript" src="/static/js/login.js"></script>
     </jsp:attribute>
     
@@ -88,13 +77,6 @@
             </p>
         </div>
                     
-        <div style="text-align: center; margin-top: 20px;">
-            <p>
-                <iframe src="http://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.facebook.com%2Fpages%2FRyyppynet%2F151477181585164&amp;layout=button_count&amp;show_faces=false&amp;width=90&amp;action=like&amp;font&amp;colorscheme=dark&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px; margin-right:20px;" allowTransparency="true"></iframe>
-                <g:plusone size="medium" href="http://ryyppy.net"></g:plusone>
-            </p>
-        </div>
-
         <div style="text-align: center; margin-top: 20px; color: #888;">
             <a href="/ui/privacy" style="color: #aaa; text-decoration: none;">Tietosuojaseloste</a>
             <span style="margin: 0 10px;">|</span>

--- a/src/main/webapp/WEB-INF/jsp/loginerror.jsp
+++ b/src/main/webapp/WEB-INF/jsp/loginerror.jsp
@@ -16,8 +16,6 @@
             <h2><spring:message code="loginerror.title" /></h2>
             <p><spring:message code="loginerror.reasons" /></p>
             <ul>
-                <li><spring:message code="loginerror.list.bad_openid" /></li>
-                <li><spring:message code="loginerror.list.no_2_0_standard" /></li>
                 <li><spring:message code="loginerror.list.login_failed" /></li>
                 <li><spring:message code="loginerror.list.bug" />
                     <a href="mailto:ryyppy.net@gmail.com"><spring:message code="loginerror.list.tell_us" /></a></li>


### PR DESCRIPTION
Login now works only via password form + Google OAuth2/One Tap, so
strip the leftovers from the old OpenID/Facebook login: dead
manualLogin()/login(openId) JS and #openId/#apNappula CSS with no
matching markup, the broken/undeclared <g:plusone> Google+ button and
Facebook Like iframe, the unused AuthMethod.FACEBOOK enum value, a
stale commented-out openId reference, and OpenID-specific message
keys/copy in the login and login-error pages.