### PR TITLE
Introduce Flyway migrations with a production baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,16 +202,10 @@
             <artifactId>spring-boot-flyway</artifactId>
         </dependency>
         <!--
-            Spring Boot 4.1.1 manages Flyway at 12.4.0, which queries
-            crdb_internal.node_build_info to detect CockroachDB's version.
-            CockroachDB v26 (used in production) restricts access to
-            crdb_internal by default, which breaks that check ("Unable to
-            determine CockroachDB version"); fixed in Flyway 12.7.0+, which
-            uses SELECT version() instead. Overridden here to the latest
-            release. CockroachDB support itself comes from the transitive
-            org.flywaydb:flyway-database-cockroachdb dependency pulled in by
-            flyway-database-postgresql below - no separate declaration
-            needed.
+            Spring Boot 4.1.1 manages Flyway at 12.4.0, whose CockroachDB
+            version check queries crdb_internal - blocked by CockroachDB v26
+            in production. Fixed in Flyway 12.7.0+ (uses SELECT version()
+            instead), so pinned to latest here.
         -->
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,14 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -206,22 +206,20 @@
             crdb_internal.node_build_info to detect CockroachDB's version.
             CockroachDB v26 restricts access to crdb_internal in production
             by default, which breaks that check ("Unable to determine
-            CockroachDB version"). Verified by inspecting each released jar's
-            bytecode directly: 12.7.0 is the first version that switched to
-            SELECT version() instead. Pinned here rather than higher because
-            flyway-database-postgresql drops CockroachDB support entirely
-            as of 13.2.0 (moved out of the free artifact) - do not bump past
-            13.1.0 without re-verifying CockroachDB is still bundled.
+            CockroachDB version"), fixed in Flyway 12.7.0+ via SELECT
+            version() instead. Pinned to latest per Redgate's official
+            database driver reference, which lists CockroachDB as supported
+            with no version cutoff.
         -->
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>12.7.0</version>
+            <version>13.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
-            <version>12.7.0</version>
+            <version>13.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -202,14 +202,16 @@
             <artifactId>spring-boot-flyway</artifactId>
         </dependency>
         <!--
-            Spring Boot 4.1.1 manages Flyway at 12.4.0, which still queries
+            Spring Boot 4.1.1 manages Flyway at 12.4.0, which queries
             crdb_internal.node_build_info to detect CockroachDB's version.
-            CockroachDB v26 restricts access to crdb_internal in production
-            by default, which breaks that check ("Unable to determine
-            CockroachDB version"), fixed in Flyway 12.7.0+ via SELECT
-            version() instead. Pinned to latest per Redgate's official
-            database driver reference, which lists CockroachDB as supported
-            with no version cutoff.
+            CockroachDB v26 (used in production) restricts access to
+            crdb_internal by default, which breaks that check ("Unable to
+            determine CockroachDB version"); fixed in Flyway 12.7.0+, which
+            uses SELECT version() instead. Overridden here to the latest
+            release. CockroachDB support itself comes from the transitive
+            org.flywaydb:flyway-database-cockroachdb dependency pulled in by
+            flyway-database-postgresql below - no separate declaration
+            needed.
         -->
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-flyway</artifactId>
         </dependency>
+        <!--
+            Spring Boot 4.1.1 manages Flyway at 12.4.0, which still queries
+            crdb_internal.node_build_info to detect CockroachDB's version.
+            CockroachDB v26 restricts access to crdb_internal in production
+            by default, which breaks that check ("Unable to determine
+            CockroachDB version"). Flyway 12.6.0 fixed this by switching to
+            SELECT version() instead - override both artifacts to it.
+        -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>12.6.0</version>
+        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+            <version>12.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,18 +206,22 @@
             crdb_internal.node_build_info to detect CockroachDB's version.
             CockroachDB v26 restricts access to crdb_internal in production
             by default, which breaks that check ("Unable to determine
-            CockroachDB version"). Flyway 12.6.0 fixed this by switching to
-            SELECT version() instead - override both artifacts to it.
+            CockroachDB version"). Verified by inspecting each released jar's
+            bytecode directly: 12.7.0 is the first version that switched to
+            SELECT version() instead. Pinned here rather than higher because
+            flyway-database-postgresql drops CockroachDB support entirely
+            as of 13.2.0 (moved out of the free artifact) - do not bump past
+            13.1.0 without re-verifying CockroachDB is still bundled.
         -->
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>12.6.0</version>
+            <version>12.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
-            <version>12.6.0</version>
+            <version>12.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,8 +198,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-flyway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         jdbc:
@@ -23,8 +23,14 @@ spring:
   session:
     timeout: 90d
     jdbc:
-      initialize-schema: always
+      # Schema is now owned by the Flyway baseline migration (see
+      # db/migration/V1__baseline.sql) instead of being (re-)applied on
+      # every boot.
+      initialize-schema: never
       cleanup-cron: "0 */15 * * * *"
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 1
   mvc:
     view:
       prefix: /WEB-INF/jsp/

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,138 @@
+-- Baseline snapshot of the production schema as it existed before Flyway was
+-- introduced. Generated from a DDL dump of the production database
+-- (chosen-quagga-4227, database ryyppynet-prod) on 2026-08-31.
+--
+-- This migration is informational: Flyway never executes it against
+-- production, because `flyway:baseline` marks V1 as already applied there.
+-- It only actually runs against a fresh, empty database (local dev, CI).
+
+create sequence hibernate_sequence;
+
+create sequence drink_seq
+    increment by 50;
+
+create sequence party_seq
+    increment by 50;
+
+create sequence users_seq
+    increment by 50;
+
+create table party
+(
+    id         bigint not null
+        primary key,
+    name       varchar(255),
+    start_time timestamp
+);
+
+create table users
+(
+    id          bigint  not null
+        primary key,
+    auth_method varchar(255),
+    email       varchar(255),
+    guest       boolean not null,
+    name        varchar(255),
+    open_id     varchar(255),
+    passphrase  varchar(255),
+    password    varchar(255),
+    sex         varchar(255),
+    weight      real    not null
+);
+
+create table drink
+(
+    id         bigint not null
+        primary key,
+    alcohol    real   not null,
+    time_stamp timestamp,
+    drinker_id bigint
+        constraint fkc82kvwq6ppaugo6wk2b90gula
+            references users
+);
+
+create table participants
+(
+    party_id       bigint not null
+        constraint fkolhjebbydtxth5axxetem5wnm
+            references party,
+    participant_id bigint not null
+        constraint fk7e4xjp7oyhhnhhv3wu2evc05
+            references users
+);
+
+-- Hibernate's auto-generated global temp tables for bulk HQL update/delete
+-- operations (one per entity: users, drink, party).
+create table hte_users
+(
+    guest       boolean,
+    id          integer,
+    rn_         integer  not null,
+    weight      real,
+    hib_sess_id char(36) not null,
+    auth_method varchar(255),
+    email       varchar(255),
+    name        varchar(255),
+    open_id     varchar(255),
+    passphrase  varchar(255),
+    password    varchar(255),
+    sex         varchar(255),
+    primary key (rn_, hib_sess_id)
+);
+
+create table hte_drink
+(
+    alcohol     real,
+    drinker_id  integer,
+    id          integer,
+    rn_         integer  not null,
+    time_stamp  timestamp(6),
+    hib_sess_id char(36) not null,
+    primary key (rn_, hib_sess_id)
+);
+
+create table hte_party
+(
+    id          integer,
+    rn_         integer  not null,
+    start_time  timestamp(6),
+    hib_sess_id char(36) not null,
+    name        varchar(255),
+    primary key (rn_, hib_sess_id)
+);
+
+-- Spring Session JDBC schema (normally managed by
+-- spring.session.jdbc.initialize-schema; now owned by this migration
+-- instead, see application.yml).
+create table spring_session
+(
+    primary_id            char(36) not null
+        constraint spring_session_pk
+            primary key,
+    session_id            char(36) not null
+        constraint spring_session_ix1
+            unique,
+    creation_time         bigint   not null,
+    last_access_time      bigint   not null,
+    max_inactive_interval bigint   not null,
+    expiry_time           bigint   not null,
+    principal_name        varchar(100)
+);
+
+create index spring_session_ix3
+    on spring_session (principal_name);
+
+create index spring_session_ix2
+    on spring_session (expiry_time);
+
+create table spring_session_attributes
+(
+    session_primary_id char(36)     not null
+        constraint spring_session_attributes_fk
+            references spring_session
+            on delete cascade,
+    attribute_name     varchar(200) not null,
+    attribute_bytes    bytea        not null,
+    constraint spring_session_attributes_pk
+        primary key (session_primary_id, attribute_name)
+);


### PR DESCRIPTION
## Summary

- Adds Flyway (`spring-boot-flyway` + `flyway-core`/`flyway-database-postgresql` pinned to 13.4.0) and a `V1__baseline.sql` migration capturing the current production schema (dumped from the live CockroachDB instance), stripped of the mixed `owner to` grants that don't translate across environments.
- Switches `spring.jpa.hibernate.ddl-auto` from `update` to `validate` - Hibernate no longer auto-mutates the schema; Flyway migrations own it from here on.
- Turns off Spring Session's own schema auto-init (`spring.session.jdbc.initialize-schema: never`), since the baseline migration now includes `spring_session`/`spring_session_attributes`.
- Enables `spring.flyway.baseline-on-migrate: true` with `baseline-version: 1`, so a deploy against an existing (pre-Flyway) schema automatically marks V1 as already-applied - no manual `flyway:baseline` step required. A fresh/empty database (local dev, CI) just runs V1 for real.
- Flyway is pinned to 13.4.0 rather than left on Spring Boot 4.1.1's managed 12.4.0: that version's CockroachDB version-detection query (`crdb_internal.node_build_info`) is blocked by CockroachDB v26's default restriction on `crdb_internal` access in production. Fixed in Flyway 12.7.0+ (switched to `SELECT version()`); pinned to latest since CockroachDB support is unaffected (ships as a transitive `flyway-database-cockroachdb` module).

## Why

The app previously had no migration tooling - schema changes went through Hibernate's `ddl-auto: update`, with no history, no repeatable path across environments, and no way to review schema changes in code review. This introduces Flyway as the path forward while safely adopting it onto production's existing schema and data without any destructive step.

## Verified

The `ryyppy.net-pr-37` Railway preview environment shares the production database, so this was validated against real production data before merge: the deploy log shows Flyway creating `flyway_schema_history`, baselining at version 1 without executing any DDL, then Hibernate validating cleanly against the real schema (`CockroachDialect`, CockroachDB 26.2.5) and the app starting normally.

## Follow-up

[#38](https://github.com/ryyppy-net/ryyppy.net/issues/38) tracks skipping `ddl-auto: validate` in production specifically (via a `production` Spring profile), since CI/PR-preview already validate schema consistency before anything reaches prod and Railway's serverless tier benefits from fast starts.

## Test plan

- [x] Verified against production's real CockroachDB instance via the PR-37 preview environment (see "Verified" above).
- [ ] Confirm `mvn test` passes (no test currently exercises the datasource, so this is not expected to be affected).
- [ ] Rotate/delete the temporary `claude` SQL user created in CockroachDB for the schema dump used to build this baseline.
