### PR TITLE
Add content-hash versioning and long-lived caching for JSP-served static assets

### DIFF
--- a/src/main/java/drinkcounter/web/WebConfiguration.java
+++ b/src/main/java/drinkcounter/web/WebConfiguration.java
@@ -1,5 +1,6 @@
 package drinkcounter.web;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
@@ -9,6 +10,8 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter;
+import org.springframework.web.servlet.resource.VersionResourceResolver;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -25,9 +28,15 @@ public class WebConfiguration implements WebMvcConfigurer {
      * WebJar assets and hand-vendored third-party builds under /static/vendor/**
      * are versioned in their URL path (e.g. /webjars/jquery/1.8.3/...,
      * /static/vendor/jquery-ui/1.8.12.custom/...), so a given URL's content
-     * never changes - safe to cache for a year. First-party static resources
-     * (everything else under /static/**) are untouched and keep the default,
-     * unversioned caching behavior.
+     * never changes - safe to cache for a year.
+     *
+     * First-party JSP-served resources under /static/css/**, /static/js/** and
+     * /static/images/** are not versioned by path, so they get a content-hash
+     * VersionResourceResolver instead: the resource chain rewrites the actual
+     * URL (e.g. /static/js/party.js -> /static/js/party-<hash>.js) whenever the
+     * file changes. JSPs must reference these paths through <c:url> so that
+     * ResourceUrlEncodingFilter (registered below) can rewrite them to the
+     * hashed URL via response.encodeURL().
      */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -40,6 +49,20 @@ public class WebConfiguration implements WebMvcConfigurer {
         registry.addResourceHandler("/static/vendor/**")
                 .addResourceLocations("classpath:/public/static/vendor/")
                 .setCacheControl(oneYearImmutable);
+
+        registry.addResourceHandler("/static/css/**", "/static/js/**", "/static/images/**")
+                .addResourceLocations("classpath:/public/static/css/", "classpath:/public/static/js/", "classpath:/public/static/images/")
+                .setCacheControl(oneYearImmutable)
+                .resourceChain(true)
+                .addResolver(new VersionResourceResolver().addContentVersionStrategy("/**"));
+    }
+
+    @Bean
+    public FilterRegistrationBean<ResourceUrlEncodingFilter> resourceUrlEncodingFilter() {
+        FilterRegistrationBean<ResourceUrlEncodingFilter> registration =
+                new FilterRegistrationBean<>(new ResourceUrlEncodingFilter());
+        registration.setDispatcherTypes(jakarta.servlet.DispatcherType.REQUEST);
+        return registration;
     }
 
     @Bean

--- a/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -4,12 +4,12 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master title="Ryyppy.net - Virhe!">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
-        <script type="text/javascript" src="/static/js/login.js"></script>
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
+        <script type="text/javascript" src="<c:url value="/static/js/login.js"/>"></script>
     </jsp:attribute>
     <jsp:body>
         <div id="logoContainer">
-            <img id="logo" src="/static/images/logo_ryyppy.png" alt="Ryyppy.net" title="Ryyppy.net" />
+            <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" />
         </div>
         
         <div class="login" style="text-align:left;padding-left:30px;">

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -4,20 +4,20 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master>
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/style.css" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
         <link rel="stylesheet" href="/static/vendor/jquery-tooltip/jquery.tooltip.css" type="text/css" media="screen" />
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
         <noscript><link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet"></noscript>
 
-        <script type="text/javascript" src="/static/js/login.js"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/login.js"/>"></script>
     </jsp:attribute>
     
     <jsp:body>
         <div id="logoContainer">
-            <img id="logo" src="/static/images/logo_ryyppy.png" alt="Ryyppy.net" title="Ryyppy.net" />
+            <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" />
             
             <p class="totalDrinkCount">
                 <spring:message code="login.already_n_drinks" arguments="${totalDrinkCount}" />

--- a/src/main/webapp/WEB-INF/jsp/loginerror.jsp
+++ b/src/main/webapp/WEB-INF/jsp/loginerror.jsp
@@ -4,12 +4,12 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master title="Ryyppy.net - Virhe sisäänkirjautumisessa!">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
-        <script type="text/javascript" src="/static/js/login.js"></script>
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
+        <script type="text/javascript" src="<c:url value="/static/js/login.js"/>"></script>
     </jsp:attribute>
     <jsp:body>
         <div id="logoContainer">
-            <img id="logo" src="/static/images/logo_ryyppy.png" alt="Ryyppy.net" title="Ryyppy.net" />
+            <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" />
         </div>
     
         <div class="login" style="text-align:left;padding-left:30px;">

--- a/src/main/webapp/WEB-INF/jsp/newuser.jsp
+++ b/src/main/webapp/WEB-INF/jsp/newuser.jsp
@@ -4,8 +4,8 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master title="Uusi juoja">
     <jsp:attribute name="customHead">
-        <script type="text/javascript" src="/static/js/common.js"></script>
-        <script type="text/javascript" src="/static/js/drinkerchecks.js"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/common.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/drinkerchecks.js"/>"></script>
         
         <link rel="stylesheet" href="/static/vendor/bootstrap/css/bootstrap.css"/>
         <link rel="stylesheet" href="/app/css/app.css"/>

--- a/src/main/webapp/WEB-INF/jsp/party.jsp
+++ b/src/main/webapp/WEB-INF/jsp/party.jsp
@@ -15,12 +15,12 @@
         <script type="text/javascript" src="/static/vendor/jquery-ui/1.8.12.custom/jquery-ui-1.8.12.custom.min.js"></script>
         <script type="text/javascript" src="/static/vendor/jquery-tmpl/jquery.tmpl.js"></script>
         
-        <script type="text/javascript" src="/static/js/common.js"></script>
-        <script type="text/javascript" src="/static/js/userbutton.js"></script>
-        <script type="text/javascript" src="/static/js/userbuttongrid.js"></script>
-        <script type="text/javascript" src="/static/js/drinkerchecks.js"></script>
-        <script type="text/javascript" src="/static/js/partygraph.js"></script>
-        <script type="text/javascript" src="/static/js/party.js"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/common.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/userbutton.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/userbuttongrid.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/drinkerchecks.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/partygraph.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/party.js"/>"></script>
 
         <script type="text/javascript">
             var partyId = ${party.id};

--- a/src/main/webapp/WEB-INF/jsp/passphrase.jsp
+++ b/src/main/webapp/WEB-INF/jsp/passphrase.jsp
@@ -4,8 +4,8 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master>
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
-        <script type="text/javascript" src="/static/js/login.js"></script>
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
+        <script type="text/javascript" src="<c:url value="/static/js/login.js"/>"></script>
         <script type="text/javascript" src="/static/vendor/zeroclipboard/ZeroClipboard.js"></script>
         <script type="text/javascript">
             ZeroClipboard.setMoviePath("/static/vendor/zeroclipboard/ZeroClipboard.swf");

--- a/src/main/webapp/WEB-INF/jsp/privacy.jsp
+++ b/src/main/webapp/WEB-INF/jsp/privacy.jsp
@@ -3,8 +3,8 @@
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <t:master title="Tietosuojaseloste - Ryyppy.net">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/style.css" />
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <style>
             .privacy-policy {
                 background-color: #000000;
@@ -65,7 +65,7 @@
     <jsp:body>
         <div id="logoContainer">
             <a href="/ui/login">
-                <img id="logo" src="/static/images/logo_ryyppy.png" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
+                <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
             </a>
         </div>
 

--- a/src/main/webapp/WEB-INF/jsp/terms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/terms.jsp
@@ -3,8 +3,8 @@
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <t:master title="Käyttöehdot - Ryyppy.net">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="/static/css/style.css" />
-        <link rel="stylesheet" type="text/css" href="/static/css/login.css" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
+        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <style>
             .terms {
                 background-color: #000000;
@@ -76,7 +76,7 @@
     <jsp:body>
         <div id="logoContainer">
             <a href="/ui/login">
-                <img id="logo" src="/static/images/logo_ryyppy.png" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
+                <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
             </a>
         </div>
 

--- a/src/main/webapp/WEB-INF/jsp/user.jsp
+++ b/src/main/webapp/WEB-INF/jsp/user.jsp
@@ -6,8 +6,8 @@
     <jsp:attribute name="customHead">
         <link rel="stylesheet" href="/static/vendor/jquery-ui/1.8.12.custom/jquery-ui-1.8.12.custom.css" type="text/css" media="screen" />
         
-        <script type="text/javascript" src="/static/js/common.js"></script>
-        <script type="text/javascript" src="/static/js/datetimepicker.js"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/common.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/datetimepicker.js"/>"></script>
         <script type="text/javascript" src="/static/vendor/jquery-ui/1.8.12.custom/jquery-ui-1.8.12.custom.min.js"></script>
         <script type="text/javascript" src="/static/vendor/jquery-ui-timepicker-addon/jquery-ui-timepicker-addon.js"></script>
         <script type="text/javascript" src="/static/vendor/jquery-ui/i18n/jquery.ui.datepicker-fi.js"></script>
@@ -17,10 +17,10 @@
         <script type="text/javascript" src="/webjars/flot/0.7/jquery.flot.min.js"></script>
         <script type="text/javascript" src="/webjars/flot/0.7/jquery.flot.crosshair.min.js"></script>
         <script type="text/javascript" src="/webjars/flot/0.7/jquery.flot.resize.min.js"></script>
-        <script type="text/javascript" src="/static/js/userbutton.js"></script>
-        <script type="text/javascript" src="/static/js/userbuttongrid.js"></script>
-        <script type="text/javascript" src="/static/js/drinkerchecks.js"></script>
-        <script type="text/javascript" src="/static/js/userhistorygraph.js"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/userbutton.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/userbuttongrid.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/drinkerchecks.js"/>"></script>
+        <script type="text/javascript" src="<c:url value="/static/js/userhistorygraph.js"/>"></script>
         <script type="text/javascript" src="/static/vendor/datejs/date.js"></script>
         <script type="text/javascript" src="/static/vendor/jquery-tmpl/jquery.tmpl.js"></script>
 
@@ -204,7 +204,7 @@
                             </span>
                         </a>
                             <a class="headerButtonA" title="<spring:message code="user.exit_dialog.title"/>" onClick="return confirm('<spring:message code="user.exit_dialog.msg"/>');" href="${leavePartyUrl}">
-                            <img src="/static/images/x.png" alt="sulje" style="float:right; margin-right: 5px;" />
+                            <img src="<c:url value="/static/images/x.png"/>" alt="sulje" style="float:right; margin-right: 5px;" />
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Adds content-hash versioning and 1-year immutable caching for JSP-served static assets (`/static/css`, `/static/js`, `/static/images`), matching the existing vendor/webjars setup. JSPs reference these through `<c:url>`, which `ResourceUrlEncodingFilter` rewrites to the hashed URL on each deploy. Vendor/webjars paths and the Angular app under `/app/**` are unchanged.

Verified: unit tests, full Playwright e2e suite, and manual checks against the Railway PR environment (hashed URLs resolve with correct `Cache-Control`/`ETag`, unrelated paths untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4kv4xyEj7MNQ8gTYBDGYb