### PR TITLE
Cache sound effects, favicon, and touch icons

### DIFF
--- a/src/main/java/drinkcounter/web/WebConfiguration.java
+++ b/src/main/java/drinkcounter/web/WebConfiguration.java
@@ -25,13 +25,19 @@ public class WebConfiguration implements WebMvcConfigurer {
      * WebJar assets and hand-vendored third-party builds under /static/vendor/**
      * are versioned in their URL path (e.g. /webjars/jquery/1.8.3/...,
      * /static/vendor/jquery-ui/1.8.12.custom/...), so a given URL's content
-     * never changes - safe to cache for a year. First-party static resources
-     * (everything else under /static/**) are untouched and keep the default,
-     * unversioned caching behavior.
+     * never changes - safe to cache for a year as immutable.
+     *
+     * Sound effects under /static/sounds/** have no version in their URL, but
+     * rarely change and the app isn't under active development, so they're
+     * also cached for a year (without .immutable(), so a hard refresh still
+     * revalidates if the file is ever replaced). Other first-party static
+     * resources (everything else under /static/**) are untouched and keep the
+     * default, unversioned caching behavior.
      */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         CacheControl oneYearImmutable = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic().immutable();
+        CacheControl oneYear = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic();
 
         registry.addResourceHandler("/webjars/**")
                 .addResourceLocations("classpath:/META-INF/resources/webjars/")
@@ -40,6 +46,10 @@ public class WebConfiguration implements WebMvcConfigurer {
         registry.addResourceHandler("/static/vendor/**")
                 .addResourceLocations("classpath:/public/static/vendor/")
                 .setCacheControl(oneYearImmutable);
+
+        registry.addResourceHandler("/static/sounds/**")
+                .addResourceLocations("classpath:/public/static/sounds/")
+                .setCacheControl(oneYear);
     }
 
     @Bean

--- a/src/main/java/drinkcounter/web/WebConfiguration.java
+++ b/src/main/java/drinkcounter/web/WebConfiguration.java
@@ -44,11 +44,18 @@ public class WebConfiguration implements WebMvcConfigurer {
      * their URL, but rarely change and the app isn't under active
      * development, so they're still cached for a year (without .immutable(),
      * so a hard refresh still revalidates if a file is ever replaced).
+     *
+     * The favicon and Apple touch icons are requested by browsers/OS via
+     * fixed, well-known root paths (not referenced through any <c:url> or
+     * <link> tag), so they can't be versioned either. They change rarely, so
+     * they get a week-long cache - short enough to roll out a replacement
+     * without a URL change, unlike the year-long caches above.
      */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         CacheControl oneYearImmutable = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic().immutable();
         CacheControl oneYear = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic();
+        CacheControl oneWeek = CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic();
 
         registry.addResourceHandler("/webjars/**")
                 .addResourceLocations("classpath:/META-INF/resources/webjars/")
@@ -67,6 +74,10 @@ public class WebConfiguration implements WebMvcConfigurer {
         registry.addResourceHandler("/static/sounds/**")
                 .addResourceLocations("classpath:/public/static/sounds/")
                 .setCacheControl(oneYear);
+
+        registry.addResourceHandler("/favicon.ico", "/apple-touch-icon.png", "/apple-touch-icon-precomposed.png")
+                .addResourceLocations("classpath:/public/")
+                .setCacheControl(oneWeek);
     }
 
     @Bean


### PR DESCRIPTION
Extends the recently-added vendored-library caching to more static resources that rarely change:

- **Sound effects** (`/static/sounds/**`): no version in the URL (referenced by plain string paths from AngularJS, not `<c:url>`), but rarely change and the app isn't under active development, so cached for a year (`max-age=365d`, `public`, without `.immutable()` so a hard refresh still revalidates if a file is ever replaced).
- **Favicon and Apple touch icons** (`favicon.ico`, `apple-touch-icon.png`, `apple-touch-icon-precomposed.png`): requested via fixed, well-known root paths rather than a `<link>`/`<c:url>` reference, so they can't be versioned. Given a shorter, week-long cache (`max-age=7d`, `public`) instead of the year-long caches used elsewhere, so a replacement icon rolls out reasonably quickly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014MMc9nbQYvVvqXYmTNnAL7