### PR TITLE
Make sessions actually last a year, not just 90 days on paper

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,15 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET:REPLACE_THIS}
 
 server:
+  servlet:
+    session:
+      cookie:
+        # Without an explicit max-age the SESSION cookie has none of its own,
+        # making it a browser-session cookie that's dropped on browser/app
+        # restart - well short of the 90-day server-side timeout above
+        # (spring.session.timeout). Match it here so the cookie actually
+        # outlives a restart.
+        max-age: 90d
   tomcat:
     # Safe only because every JSP is precompiled and registered directly by
     # PrecompiledJspServletInitializer - nothing compiles a JSP at runtime, so

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
             # instead of probing for one.
             non_contextual_creation: true
   session:
-    timeout: 90d
+    timeout: 365d
     jdbc:
       # Schema is now owned by the Flyway baseline migration (see
       # db/migration/V1__baseline.sql) instead of being (re-)applied on
@@ -56,10 +56,10 @@ server:
       cookie:
         # Without an explicit max-age the SESSION cookie has none of its own,
         # making it a browser-session cookie that's dropped on browser/app
-        # restart - well short of the 90-day server-side timeout above
+        # restart - well short of the server-side timeout above
         # (spring.session.timeout). Match it here so the cookie actually
         # outlives a restart.
-        max-age: 90d
+        max-age: 365d
   tomcat:
     # Safe only because every JSP is precompiled and registered directly by
     # PrecompiledJspServletInitializer - nothing compiles a JSP at runtime, so


### PR DESCRIPTION
## Summary
- Users were getting logged out well before the configured 90-day session timeout because the `SESSION` cookie had no explicit `max-age`, making it a browser-session cookie that's dropped on browser/app restart regardless of the server-side session lifetime.
- Set `server.servlet.session.cookie.max-age` to match `spring.session.timeout`.
- Bumped both from 90 days to a year, since this is a social app and long-lived sessions (rather than a remember-me flow) are the desired UX for everyone.

## Test plan
- [x] `mvn compile` succeeds with the updated `application.yml`
- [ ] Manually verify in a deployed environment that the `SESSION` cookie now carries a ~1 year `Max-Age`/`Expires` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5wknURpRb19ffGNAVxCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ5wknURpRb19ffGNAVxCQ)_