### PR TITLE
Fix Google sign-in origin_mismatch on non-hub environments

### DIFF
--- a/src/main/java/drinkcounter/authentication/OAuth2Configuration.java
+++ b/src/main/java/drinkcounter/authentication/OAuth2Configuration.java
@@ -1,5 +1,7 @@
 package drinkcounter.authentication;
 
+import drinkcounter.authentication.relay.AuthRelayTokenService;
+import drinkcounter.authentication.relay.RelayAwareAuthenticationSuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -20,7 +22,8 @@ public class OAuth2Configuration {
     @Bean
     public Customizer<HttpSecurity> oauth2LoginCustomizer(
             CustomOAuth2UserService customOAuth2UserService,
-            OidcUserService oidcUserService) {
+            OidcUserService oidcUserService,
+            RelayAwareAuthenticationSuccessHandler relayAwareAuthenticationSuccessHandler) {
         return http -> {
             try {
                 http.oauth2Login(oauth2 -> oauth2
@@ -29,12 +32,22 @@ public class OAuth2Configuration {
                         .oidcUserService(oidcUserService)
                         .userService(customOAuth2UserService)
                     )
-                    .defaultSuccessUrl("/app/index.html", true)
+                    .successHandler(relayAwareAuthenticationSuccessHandler)
                 );
             } catch (Exception e) {
                 throw new RuntimeException("Failed to configure OAuth2 login", e);
             }
         };
+    }
+
+    /**
+     * Completes classical OAuth2 login. When the login was started via the cross-environment
+     * relay (see AuthRelayController), hands the verified identity back to the environment that
+     * started it; otherwise this is an ordinary successful login on the current host.
+     */
+    @Bean
+    public RelayAwareAuthenticationSuccessHandler relayAwareAuthenticationSuccessHandler(AuthRelayTokenService tokenService) {
+        return new RelayAwareAuthenticationSuccessHandler(tokenService);
     }
 
     /**

--- a/src/main/java/drinkcounter/authentication/relay/AuthRelayController.java
+++ b/src/main/java/drinkcounter/authentication/relay/AuthRelayController.java
@@ -9,15 +9,33 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
- * Completes the cross-environment Google sign-in relay: verifies the signed handoff token minted
- * by the hub environment (see GoogleOneTapController) and establishes a session here, on the
- * environment the user actually started on.
+ * Endpoints for the cross-environment Google sign-in relay.
+ *
+ * Google Identity Services (One Tap / the styled sign-in button) checks the *page's own origin*
+ * against Google's Authorized JavaScript origins before it lets sign-in proceed at all - a check
+ * that happens entirely on Google's side and can't be relayed, so it always fails with
+ * origin_mismatch on Railway's ephemeral, unregistered PR domains. The classical OAuth2
+ * authorization-code flow only checks the *redirect URI*, so instead of initiating it locally,
+ * a non-hub environment bounces the user through the hub (the one domain actually registered with
+ * Google):
+ *
+ *  1. {@link #redirect} (this environment) signs its own origin and sends the browser to the
+ *     hub's {@link #start}.
+ *  2. {@link #start} (the hub) verifies that signature, stashes the origin in its session, and
+ *     kicks off Spring Security's normal /oauth2/authorization/google flow.
+ *  3. On success, RelayAwareAuthenticationSuccessHandler mints a handoff token and sends the
+ *     browser back to {@link #complete}, on the environment that started the sign-in.
  */
 @Controller
 public class AuthRelayController {
 
     private static final Logger log = LoggerFactory.getLogger(AuthRelayController.class);
+
+    static final String RETURN_TO_SESSION_ATTR = "authRelay.returnTo";
 
     private final AuthRelayTokenService tokenService;
     private final GoogleIdentityLinkingService identityLinkingService;
@@ -25,6 +43,38 @@ public class AuthRelayController {
     public AuthRelayController(AuthRelayTokenService tokenService, GoogleIdentityLinkingService identityLinkingService) {
         this.tokenService = tokenService;
         this.identityLinkingService = identityLinkingService;
+    }
+
+    @GetMapping("/api/auth/relay/redirect")
+    public String redirect(HttpServletRequest request) {
+        String hubUrl = System.getenv("GOOGLE_AUTH_HUB_URL");
+        if (!tokenService.isEnabled() || hubUrl == null || hubUrl.isBlank()) {
+            log.error("Google sign-in relay was requested but GOOGLE_AUTH_HUB_URL/AUTH_RELAY_SECRET are not configured");
+            return "redirect:/ui/login?error=relay_not_configured";
+        }
+
+        String ownOrigin = Origins.of(request);
+        String signature = tokenService.signOrigin(ownOrigin);
+
+        String target = hubUrl.replaceAll("/+$", "") + "/api/auth/relay/start"
+                + "?return_to=" + URLEncoder.encode(ownOrigin, StandardCharsets.UTF_8)
+                + "&sig=" + URLEncoder.encode(signature, StandardCharsets.UTF_8);
+        return "redirect:" + target;
+    }
+
+    @GetMapping("/api/auth/relay/start")
+    public String start(
+            @RequestParam("return_to") String returnTo,
+            @RequestParam("sig") String sig,
+            HttpServletRequest request) {
+
+        if (!tokenService.verifyOriginSignature(returnTo, sig)) {
+            log.warn("Auth relay start rejected: invalid signature for return_to={}", returnTo);
+            return "redirect:/ui/login?error=invalid_relay_request";
+        }
+
+        request.getSession(true).setAttribute(RETURN_TO_SESSION_ATTR, returnTo);
+        return "redirect:/oauth2/authorization/google";
     }
 
     @GetMapping("/api/auth/relay/complete")

--- a/src/main/java/drinkcounter/authentication/relay/AuthRelayTokenService.java
+++ b/src/main/java/drinkcounter/authentication/relay/AuthRelayTokenService.java
@@ -76,6 +76,25 @@ public class AuthRelayTokenService {
     }
 
     /**
+     * Signs a plain origin string - used for the "return_to" a non-hub environment sends the hub
+     * when starting the classical OAuth2 flow (see AuthRelayController#redirect/#start). This
+     * proves the origin was produced by an environment holding our shared secret rather than an
+     * arbitrary caller, without needing to trust anything about the URL's shape - Railway's own
+     * domains aren't unique to us, so pattern-matching the hostname wouldn't be safe here.
+     */
+    public String signOrigin(String origin) {
+        return sign(origin, requireSecret());
+    }
+
+    public boolean verifyOriginSignature(String origin, String signature) {
+        String secret = getSecret();
+        if (secret == null || signature == null) {
+            return false;
+        }
+        return constantTimeEquals(signature, sign(origin, secret));
+    }
+
+    /**
      * Verifies signature, expiry, single-use, and that the token was minted for exactly this
      * origin (so a token intercepted en route can't be replayed against a different environment).
      */

--- a/src/main/java/drinkcounter/authentication/relay/RelayAwareAuthenticationSuccessHandler.java
+++ b/src/main/java/drinkcounter/authentication/relay/RelayAwareAuthenticationSuccessHandler.java
@@ -1,0 +1,56 @@
+package drinkcounter.authentication.relay;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Completes classical OAuth2 login on the hub. If this login was started via the relay (see
+ * AuthRelayController#redirect / #start), mints a handoff token for the verified Google identity
+ * and sends the browser back to the environment that started the sign-in. Otherwise behaves like
+ * an ordinary successful login on this environment.
+ */
+public class RelayAwareAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(RelayAwareAuthenticationSuccessHandler.class);
+
+    private final AuthRelayTokenService tokenService;
+
+    public RelayAwareAuthenticationSuccessHandler(AuthRelayTokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+        HttpSession session = request.getSession(false);
+        String returnTo = session != null
+                ? (String) session.getAttribute(AuthRelayController.RETURN_TO_SESSION_ATTR)
+                : null;
+
+        if (returnTo != null) {
+            session.removeAttribute(AuthRelayController.RETURN_TO_SESSION_ATTR);
+
+            OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+            String sub = oauth2User.getAttribute("sub");
+            String email = oauth2User.getAttribute("email");
+            String name = oauth2User.getAttribute("name");
+
+            String token = tokenService.mint(sub, email, name, returnTo);
+            log.info("OAuth2 login: relaying verified Google identity to {}", returnTo);
+            response.sendRedirect(returnTo + "/api/auth/relay/complete?token=" + URLEncoder.encode(token, StandardCharsets.UTF_8));
+            return;
+        }
+
+        response.sendRedirect("/app/index.html");
+    }
+}

--- a/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
+++ b/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
@@ -81,6 +81,29 @@ public class GlobalControllerAdvice {
     }
 
     /**
+     * Whether this environment is the hub Google is actually registered for.
+     *
+     * Google Identity Services (One Tap / the styled sign-in button) checks the page's own origin
+     * against Google's Authorized JavaScript origins before it lets sign-in proceed - a check that
+     * happens entirely on Google's side and can't be relayed. So on any environment that isn't the
+     * hub, login.jsp shows a plain link into the classical OAuth2 relay
+     * (/api/auth/relay/redirect) instead of the GSI widget, which would otherwise fail there with
+     * origin_mismatch.
+     *
+     * Unset GOOGLE_AUTH_HUB_URL means there's no separate hub configured (e.g. local dev, or a
+     * single-environment deployment), so every environment is treated as the hub.
+     * Available in JSP as ${isHubEnvironment}
+     */
+    @ModelAttribute("isHubEnvironment")
+    public boolean isHubEnvironment(HttpServletRequest request) {
+        String hubUrl = System.getenv("GOOGLE_AUTH_HUB_URL");
+        if (hubUrl == null || hubUrl.isBlank()) {
+            return true;
+        }
+        return Origins.of(request).equalsIgnoreCase(hubUrl.replaceAll("/+$", ""));
+    }
+
+    /**
      * Checks if GitHub OAuth2 login is enabled.
      * Available in JSP as ${githubAuthEnabled}
      */

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -38,27 +38,48 @@
             </p>
 
             <c:if test="${googleAuthEnabled}">
-                        <div id="g_id_onload"
-                             data-client_id="${googleClientId}"
-                             data-context="use"
-                             data-ux_mode="popup"
-                             data-login_uri="${oneTapLoginUri}"
-                             data-auto_select="${param.logout == null}"
-                             data-itp_support="true"
-                             data-use_fedcm_for_prompt="${useFedCm}">
-                        </div>
+                        <c:choose>
+                            <c:when test="${isHubEnvironment}">
+                                <div id="g_id_onload"
+                                     data-client_id="${googleClientId}"
+                                     data-context="use"
+                                     data-ux_mode="popup"
+                                     data-login_uri="${oneTapLoginUri}"
+                                     data-auto_select="${param.logout == null}"
+                                     data-itp_support="true"
+                                     data-use_fedcm_for_prompt="${useFedCm}">
+                                </div>
 
-                        <div style="display: flex; justify-content: center; margin: 20px 0;">
-                            <div class="g_id_signin"
-                                 data-type="standard"
-                                 data-shape="pill"
-                                 data-theme="outline"
-                                 data-text="continue_with"
-                                 data-size="large"
-                                 data-locale="fi"
-                                 data-logo_alignment="left">
-                            </div>
-                        </div>
+                                <div style="display: flex; justify-content: center; margin: 20px 0;">
+                                    <div class="g_id_signin"
+                                         data-type="standard"
+                                         data-shape="pill"
+                                         data-theme="outline"
+                                         data-text="continue_with"
+                                         data-size="large"
+                                         data-locale="fi"
+                                         data-logo_alignment="left">
+                                    </div>
+                                </div>
+                            </c:when>
+                            <c:otherwise>
+                                <%-- Google's One Tap widget checks the page's own origin against
+                                     Google's Authorized JavaScript origins before allowing
+                                     sign-in, which always fails here since this isn't the
+                                     registered hub domain. Use the classical OAuth2 relay
+                                     instead, which only checks the redirect URI. --%>
+                                <div style="display: flex; justify-content: center; margin: 20px 0;">
+                                    <a href="/api/auth/relay/redirect"
+                                       style="display: inline-flex; align-items: center;
+                                              padding: 10px 24px; border-radius: 999px;
+                                              border: 1px solid #dadce0; background: #fff;
+                                              color: #3c4043; font-family: Roboto, sans-serif;
+                                              font-size: 14px; text-decoration: none;">
+                                        Continue with Google
+                                    </a>
+                                </div>
+                            </c:otherwise>
+                        </c:choose>
                     </c:if>
 
             <p>Eikö sinulla ole vielä tunnuksia? <a href="newuser">Rekisteröi itsesi saadaksesi tunnukset</a>

--- a/src/test/java/drinkcounter/authentication/relay/AuthRelayTokenServiceTest.java
+++ b/src/test/java/drinkcounter/authentication/relay/AuthRelayTokenServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AuthRelayTokenServiceTest {
 
@@ -72,6 +73,39 @@ public class AuthRelayTokenServiceTest {
         AuthRelayTokenService tokenService = withSecret("test-secret");
 
         assertThrows(AuthRelayException.class, () -> tokenService.verify("not-a-real-token", ORIGIN));
+    }
+
+    @Test
+    public void originSignatureRoundTrips() {
+        AuthRelayTokenService tokenService = withSecret("test-secret");
+
+        String signature = tokenService.signOrigin(ORIGIN);
+
+        assertTrue(tokenService.verifyOriginSignature(ORIGIN, signature));
+    }
+
+    @Test
+    public void originSignatureIsRejectedForADifferentOrigin() {
+        AuthRelayTokenService tokenService = withSecret("test-secret");
+
+        String signature = tokenService.signOrigin(ORIGIN);
+
+        assertFalse(tokenService.verifyOriginSignature("https://attacker.up.railway.app", signature));
+    }
+
+    @Test
+    public void originSignatureFromADifferentSecretIsRejected() {
+        String signature = withSecret("secret-a").signOrigin(ORIGIN);
+
+        assertFalse(withSecret("secret-b").verifyOriginSignature(ORIGIN, signature));
+    }
+
+    @Test
+    public void originSignatureVerificationFailsSafeWithoutASecret() {
+        AuthRelayTokenService tokenService = withSecret(null);
+
+        assertThrows(IllegalStateException.class, () -> tokenService.signOrigin(ORIGIN));
+        assertFalse(tokenService.verifyOriginSignature(ORIGIN, "anything"));
     }
 
     /** Uses the package-private test constructor to fix a secret instead of relying on the environment. */


### PR DESCRIPTION
## Summary

Follow-up to #49. Testing that PR's PR-preview environment surfaced `origin_mismatch` on the Google sign-in button (`accounts.google.com/signin/oauth/error` → "Access blocked: Authorization Error... Error 400: origin_mismatch").

**Root cause:** Google Identity Services (One Tap / the styled `g_id_signin` button) checks the *page's own origin* against Google's "Authorized JavaScript origins" before it lets sign-in proceed at all. That check happens entirely on Google's side, before any of our code runs, and is a *different* check from the `login_uri` redirect-target validation #49 already fixed. Pointing `login_uri` at the hub didn't help, because the button itself was still running on the PR environment's unregistered origin — so it always failed with `origin_mismatch` there, regardless of the relay.

**Fix:** non-hub environments now use the classical OAuth2 authorization-code flow instead, which only validates the *redirect URI* (already fixable via the hub), not the initiating page's origin:

- `GET /api/auth/relay/redirect` (this environment) signs its own origin (HMAC, `AUTH_RELAY_SECRET`) and sends the browser to the hub's `/api/auth/relay/start`.
- `GET /api/auth/relay/start` (the hub) verifies that signature, stashes the origin in its session, and kicks off Spring Security's existing `/oauth2/authorization/google` flow (already wired, just never linked from the UI before).
- `RelayAwareAuthenticationSuccessHandler` mints a handoff token on success and sends the browser back to `/api/auth/relay/complete` on the originating environment — reusing the handoff-token machinery from #49 unchanged.

`login.jsp` now shows the GSI widget only when `${isHubEnvironment}` is true (production's behavior is unchanged), and a plain "Continue with Google" link everywhere else, which goes through the new relay path.

## Test plan

- [x] `mvn test` — full suite green, including 4 new unit tests for `AuthRelayTokenService`'s origin-signing (round-trip, wrong-origin rejection, wrong-secret rejection, fail-safe without a secret)
- [ ] Open a fresh PR to spin up a preview environment and verify the "Continue with Google" link completes sign-in without `origin_mismatch`
- [ ] Verify production's One Tap widget still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGhuhvT33SZAakDJtEfu51