### PR TITLE
Fix party start time misparsing on party list/dashboard

### DIFF
--- a/e2e/tests/party-and-drinking.spec.ts
+++ b/e2e/tests/party-and-drinking.spec.ts
@@ -1,6 +1,28 @@
 import { test, expect } from '@playwright/test';
 import { makeTestUser, registerUser, createParty } from './helpers';
 
+test('a newly created party shows its actual start date, not a misparsed one', async ({ page }) => {
+  // Regression test: the party list used to parse the ISO-8601 startTime the
+  // API returns with a moment format string meant for a completely different
+  // date shape ('MMM DD, YYYY h:mm:ss A'), which silently misparsed today's
+  // date into a garbage one (see filters.js formatDateTime / partySort).
+  const user = makeTestUser('party-date');
+  await registerUser(page, user);
+
+  const partyName = `E2E Date Party ${Date.now()}`;
+  await createParty(page, partyName);
+
+  await page.goto('/app/index.html#/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('h2', { hasText: 'Bileesi' })).toBeVisible();
+
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const expectedDate = `${pad(now.getDate())}.${pad(now.getMonth() + 1)}.${pad(now.getFullYear() % 100)}`;
+
+  const partyTile = page.locator('.party', { has: page.getByText(partyName) });
+  await expect(partyTile.getByText('Alkamisaika:').locator('..')).toContainText(expectedDate);
+});
+
 test('a user can create a party, appear as a participant, and logging a drink updates their promille level', async ({ page }) => {
   const user = makeTestUser('party');
   await registerUser(page, user);

--- a/src/main/resources/public/app/js/controllers/GeneralPartyAdminCtrl.js
+++ b/src/main/resources/public/app/js/controllers/GeneralPartyAdminCtrl.js
@@ -29,7 +29,7 @@ function GeneralPartyAdminCtrl($scope, $location, RyyppyAPI, Notify) {
     };
 
     $scope.partySort = function (party) {
-        return moment(party.startTime, 'MMM DD, YYYY h:mm:ss A');
+        return moment(party.startTime);
     };
 
     $scope.active = 'general-party-admin';

--- a/src/main/resources/public/app/js/controllers/UserCtrl.js
+++ b/src/main/resources/public/app/js/controllers/UserCtrl.js
@@ -43,7 +43,7 @@ function UserCtrl($scope, $timeout, RyyppyAPI, Notify) {
     };
 
     $scope.partySort = function (party) {
-        return moment(party.startTime, 'MMM DD, YYYY h:mm:ss A');
+        return moment(party.startTime);
     };
 
     $scope.drinkSort = function (drink) {

--- a/src/main/resources/public/app/js/filters.js
+++ b/src/main/resources/public/app/js/filters.js
@@ -5,7 +5,7 @@
 angular.module('ryyppy.filters', []).
     filter('formatDateTime', [function() {
         return function(text) {
-            return moment(text, 'MMM DD, YYYY h:mm:ss A').format("DD.MM.YY klo H");
+            return moment(text).format("DD.MM.YY klo H");
         }
     }]).
     filter('formatISODateTime', [function() {


### PR DESCRIPTION
## Summary
- The party list (`Sinä` dashboard and party admin page) parsed the API's ISO-8601 `startTime` with a moment format string meant for a completely different date shape (`'MMM DD, YYYY h:mm:ss A'`), which silently misparsed the value instead of failing loudly.
- Older parties happened to misparse into plausible-looking (but still wrong) dates, which is why this went unnoticed. A freshly created party (today's date) misparsed into an obviously wrong one — e.g. showing `09.01.06 klo 7` right after creation instead of the actual creation date.
- `formatDateTime` (filters.js) and both `partySort` implementations (`GeneralPartyAdminCtrl.js`, `UserCtrl.js`) now parse `startTime` the same way `formatISODateTime` already parses `drink.timestamp`: `moment(text)` with no format string.
- Added an e2e regression test that creates a party and asserts the dashboard shows today's actual date. Verified it fails with exactly the original bug's garbled value when the fix is reverted, and passes with the fix.

## Test plan
- [x] `mvn compile` succeeds after merging latest `main`
- [x] Ran the full Playwright e2e suite locally (local Postgres instead of Docker Compose in this sandbox) — all 6 tests pass, including the new regression test
- [x] Confirmed the new test fails with the pre-fix code, reproducing the exact `09.01.06 klo 7` garbled output from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qh9LHwLxA2briWUTwVK6t

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qh9LHwLxA2briWUTwVK6t)_