### PR TITLE
Log the start of a Google sign-in relay, not just its outcome

### DIFF
--- a/src/main/java/drinkcounter/authentication/relay/AuthRelayController.java
+++ b/src/main/java/drinkcounter/authentication/relay/AuthRelayController.java
@@ -56,6 +56,8 @@ public class AuthRelayController {
         String ownOrigin = Origins.of(request);
         String signature = tokenService.signOrigin(ownOrigin);
 
+        log.info("Auth relay: {} starting sign-in via hub", ownOrigin);
+
         String target = hubUrl.replaceAll("/+$", "") + "/api/auth/relay/start"
                 + "?return_to=" + URLEncoder.encode(ownOrigin, StandardCharsets.UTF_8)
                 + "&sig=" + URLEncoder.encode(signature, StandardCharsets.UTF_8);
@@ -72,6 +74,8 @@ public class AuthRelayController {
             log.warn("Auth relay start rejected: invalid signature for return_to={}", returnTo);
             return "redirect:/ui/login?error=invalid_relay_request";
         }
+
+        log.info("Auth relay: hub received valid start request for {}", returnTo);
 
         request.getSession(true).setAttribute(RETURN_TO_SESSION_ATTR, returnTo);
         return "redirect:/oauth2/authorization/google";


### PR DESCRIPTION
## Summary

Follow-up to #51. The relay was silent until it either completed or failed with a reason, so there was no way to tell "nobody's tried the Google button" apart from "people are starting the relay and abandoning it at Google's consent screen."

Adds one log line at each of:
- `/api/auth/relay/redirect` (the non-hub environment initiating the relay) — logs the originating environment before redirecting to the hub.
- `/api/auth/relay/start` on its success path (the hub receiving a validly-signed request) — previously only the rejection path was logged.

Together with the existing completion/rejection logs, this makes the whole funnel (started → reached hub → completed) visible across both environments' logs.

## Test plan

- [x] `mvn test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGhuhvT33SZAakDJtEfu51

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGhuhvT33SZAakDJtEfu51)_