### PR TITLE
Fix old UI showing NaN alcohol by dropping stray trailing slashes

### DIFF
--- a/src/main/resources/public/static/js/common.js
+++ b/src/main/resources/public/static/js/common.js
@@ -9,7 +9,7 @@ var RyyppyNet = {
 
 function RyyppyAPI() {
     this.getUserData = function(userId, callback) {
-        $.get('/API/users/{0}/'.format(userId), callback);
+        $.get('/API/users/{0}'.format(userId), callback);
     }
 
     this.getUserDrinks = function(userId, callback) {
@@ -38,7 +38,7 @@ function RyyppyAPI() {
     }
 
     this.getPartyData = function(partyId, callback) {
-        $.get('/API/parties/{0}/'.format(partyId), callback);
+        $.get('/API/parties/{0}'.format(partyId), callback);
     }
     
     this.addAnonymousUserToParty = function(partyId, name, sex, weight, successCallback, errorCallback) {

--- a/src/main/resources/public/static/mob/js/api.js
+++ b/src/main/resources/public/static/mob/js/api.js
@@ -9,7 +9,7 @@ String.prototype.format = function() {
 
 function RyyppyAPI() {
     this.getUserData = function(userId, callback) {
-        $.get('/API/users/{0}/'.format(userId), callback);
+        $.get('/API/users/{0}'.format(userId), callback);
     }
 
     this.getUserDrinks = function(userId, callback) {
@@ -38,7 +38,7 @@ function RyyppyAPI() {
     }
 
     this.getPartyData = function(partyId, callback) {
-        $.get('/API/parties/{0}/'.format(partyId), callback);
+        $.get('/API/parties/{0}'.format(partyId), callback);
     }
     
     this.addAnonymousUserToParty = function(partyId, name, sex, weight, successCallback, errorCallback) {


### PR DESCRIPTION
## Summary
- `RyyppyAPI.getUserData` and `getPartyData` in the classic jQuery UI (`static/js/common.js`) and its mobile counterpart (`static/mob/js/api.js`) requested `/API/users/{id}/` and `/API/parties/{id}/` with a trailing slash, but the Spring MVC mappings are `/API/users/{userId}` and `/API/parties/{partyId}` without one.
- Spring's `PathPatternParser` (verified against this project's Spring Framework 7.0.9) no longer matches an optional trailing slash by default, so these two requests always 404 and their success callback never runs.
- Each user button is initialized with a "loading" placeholder (`setTexts(getMessage('loading'), 0, 0, 0)`), and since that placeholder is rendered through `Number(...).toFixed(2)`, it displays as `NaN‰` — and because the request that's supposed to overwrite it with real data never succeeds, it stays `NaN` no matter how many drinks are logged.
- Fix: drop the trailing slash from both request URLs in both files so they match the actual controller mappings.

## Test plan
- [x] `mvn test -Dtest=UserTest,APIControllerTest` passes
- [x] Verified the path-matching behavior directly against this project's Spring Framework 7.0.9 (`PathPatternParser`): `/API/parties/{partyId}` matches `/API/parties/5` but not `/API/parties/5/`
- [ ] Manual verification in a running app (not possible in this sandbox — no Docker/Postgres available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpJHSkawFnmUr82tA8frqi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpJHSkawFnmUr82tA8frqi)_