### PR TITLE
Fix client/server timezone mismatch in drink-history CSV export

### DIFF
--- a/src/main/java/drinkcounter/web/controllers/api/APIController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/APIController.java
@@ -14,10 +14,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -66,6 +66,8 @@ public class APIController {
 
     @Autowired
     private UserService userService;
+
+    private Clock clock = Clock.systemUTC();
 
     @RequestMapping("/parties/{partyId}")
     public @ResponseBody byte[] printXml(HttpSession session, @PathVariable String partyId) throws IOException{
@@ -135,9 +137,10 @@ public class APIController {
         Map<String, Integer> drinksPerDay = new LinkedHashMap<String, Integer>();
         DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+        double timezoneOffset = (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
+        ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int)(-timezoneOffset * 60));
+
         for (Drink d : drinks) {
-            double timezoneOffset = (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
-            ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int)(-timezoneOffset * 60));
             String s = d.getTimeStamp().atZone(dtz).format(format);
 
             Integer i = 0;
@@ -147,7 +150,7 @@ public class APIController {
             drinksPerDay.put(s, i);
         }
 
-        String today = LocalDate.now(ZoneId.systemDefault()).format(format);
+        String today = LocalDate.now(clock.withZone(dtz)).format(format);
         if (!drinksPerDay.containsKey(today))
             drinksPerDay.put(today, 0);
 
@@ -158,7 +161,7 @@ public class APIController {
         csvWriter.writeRecord(new String[]{"Time", "Drinks"});
 
         for (Entry<String, Integer> p : drinksPerDay.entrySet()) {
-            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(dtz).toInstant().toEpochMilli();
             csvWriter.writeRecord(new String[]{Long.toString(millis), p.getValue().toString()});
         }
 

--- a/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
@@ -15,9 +15,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -38,6 +38,8 @@ public class ProfileApiController {
     private final DrinkCounterService drinkCounterService;
     private final UserService userService;
     private final CurrentUser currentUser;
+
+    private Clock clock = Clock.systemUTC();
 
     public ProfileApiController(DrinkCounterService drinkCounterService, UserService userService, CurrentUser currentUser) {
         this.drinkCounterService = drinkCounterService;
@@ -112,9 +114,10 @@ public class ProfileApiController {
         Map<String, Integer> drinksPerDay = new LinkedHashMap<String, Integer>();
         DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+        double timezoneOffset = 0; // (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
+        ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int)(-timezoneOffset * 60));
+
         for (Drink d : drinks) {
-            double timezoneOffset = 0; // (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
-            ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int)(-timezoneOffset * 60));
             String s = d.getTimeStamp().atZone(dtz).format(format);
 
             Integer i = 0;
@@ -124,7 +127,7 @@ public class ProfileApiController {
             drinksPerDay.put(s, i);
         }
 
-        String today = LocalDate.now(ZoneId.systemDefault()).format(format);
+        String today = LocalDate.now(clock.withZone(dtz)).format(format);
         if (!drinksPerDay.containsKey(today))
             drinksPerDay.put(today, 0);
 
@@ -135,7 +138,7 @@ public class ProfileApiController {
         csvWriter.writeRecord(new String[]{"Time", "Drinks"});
 
         for (Map.Entry<String, Integer> p : drinksPerDay.entrySet()) {
-            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(dtz).toInstant().toEpochMilli();
             csvWriter.writeRecord(new String[]{Long.toString(millis), p.getValue().toString()});
         }
 

--- a/src/test/java/drinkcounter/web/controllers/api/APIControllerTest.java
+++ b/src/test/java/drinkcounter/web/controllers/api/APIControllerTest.java
@@ -14,10 +14,14 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.Clock;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -47,9 +51,91 @@ public class APIControllerTest {
         ReflectionTestUtils.setField(controller, "authenticationChecks", authenticationChecks);
     }
 
+    private TimeZone originalDefaultTimeZone;
+
+    @AfterEach
+    public void restoreDefaultTimeZone() {
+        if (originalDefaultTimeZone != null) {
+            TimeZone.setDefault(originalDefaultTimeZone);
+        }
+    }
+
+    // Issue #55: the CSV "Time" column for a day bucket must represent
+    // midnight in the CLIENT's zone (the same zone used to decide which
+    // bucket the drink belongs to), not the server's JVM zone.
+    @Test
+    public void drinkHistoryTimeColumnRepresentsMidnightInClientZone_issue55() throws Exception {
+        originalDefaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+        // Client reports UTC+2 using JS convention (offset = -120).
+        when(session.getAttribute(AuthenticationController.TIMEZONEOFFSET)).thenReturn(-120.0);
+
+        User user = new User();
+        user.setId(1);
+
+        Drink drink = new Drink();
+        drink.setTimeStamp(Instant.parse("2024-03-05T22:30:00Z")); // 2024-03-06T00:30 in client zone
+        user.drink(drink);
+
+        when(userService.getUser(1)).thenReturn(user);
+
+        ResponseEntity<byte[]> response = controller.drinkHistory(session, "1");
+
+        long millis = findMillisForClientDay(response.getBody(), ZoneOffset.ofHours(2), "2024-03-06");
+
+        long clientMidnightMillis = Instant.parse("2024-03-05T22:00:00Z").toEpochMilli();
+        assertEquals(clientMidnightMillis, millis,
+                "Time column should be midnight 2024-03-06 in the CLIENT's zone (UTC+2), "
+                + "not the server's zone (America/Los_Angeles)");
+    }
+
+    private long findMillisForClientDay(byte[] csv, ZoneOffset clientZone, String targetDay) throws Exception {
+        CsvReader reader = new CsvReader(new ByteArrayInputStream(csv), java.nio.charset.StandardCharsets.UTF_8);
+        reader.readHeaders();
+        long result = -1;
+        while (reader.readRecord()) {
+            long millis = Long.parseLong(reader.get(0));
+            String dayInClientZone = Instant.ofEpochMilli(millis).atZone(clientZone).toLocalDate().toString();
+            if (dayInClientZone.equals(targetDay)) {
+                result = millis;
+            }
+        }
+        reader.close();
+        if (result == -1) {
+            throw new AssertionError("No row found for day " + targetDay + " in client zone " + clientZone);
+        }
+        return result;
+    }
+
+    // Issue #55: "today" must always be decided in the CLIENT's zone,
+    // not the server's. Client at UTC+14 (Kiritimati); a fixed instant
+    // that is already the next calendar day there while UTC is still on
+    // the previous day.
+    @Test
+    public void drinkHistoryTodayBucketUsesClientZone_issue55() throws Exception {
+        when(session.getAttribute(AuthenticationController.TIMEZONEOFFSET)).thenReturn(-840.0); // UTC+14
+
+        Clock fixedClock = Clock.fixed(Instant.parse("2024-03-05T23:00:00Z"), ZoneOffset.UTC);
+        ReflectionTestUtils.setField(controller, "clock", fixedClock);
+
+        User user = new User();
+        user.setId(1); // no drinks: only the "today" bucket will be present
+
+        when(userService.getUser(1)).thenReturn(user);
+
+        ResponseEntity<byte[]> response = controller.drinkHistory(session, "1");
+
+        Map<String, Integer> countsByDay = parseTimeCountCsv(response.getBody(), ZoneOffset.ofHours(14));
+
+        assertTrue(countsByDay.containsKey("2024-03-06"),
+                "today's bucket should be 2024-03-06 (client's UTC+14 date), not 2024-03-05 (UTC/server date)");
+    }
+
     @Test
     public void drinkHistoryBucketsDrinksByClientLocalDay() throws Exception {
         // Client timezone offset is JS-style: UTC+02:00 is reported as -120.
+        ZoneOffset clientZone = ZoneOffset.ofHours(2);
         when(session.getAttribute(AuthenticationController.TIMEZONEOFFSET)).thenReturn(-120.0);
 
         User user = new User();
@@ -66,12 +152,15 @@ public class APIControllerTest {
 
         ResponseEntity<byte[]> response = controller.drinkHistory(session, "1");
 
-        Map<String, Integer> countsByDay = parseTimeCountCsv(response.getBody());
+        // The "Time" column is only meaningful when decoded in the same zone
+        // the server used to produce it: the client's zone (dtz), not the
+        // server's own systemDefault().
+        Map<String, Integer> countsByDay = parseTimeCountCsv(response.getBody(), clientZone);
 
         assertEquals(1, countsByDay.getOrDefault("2024-03-05", 0));
         assertEquals(1, countsByDay.getOrDefault("2024-03-06", 0));
 
-        String today = LocalDate.now(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String today = LocalDate.now(clientZone).format(DateTimeFormatter.ISO_LOCAL_DATE);
         assertTrue(countsByDay.containsKey(today), "should always include today's bucket");
     }
 
@@ -105,14 +194,14 @@ public class APIControllerTest {
                 "last point should be ~now, was " + lastTimestamp);
     }
 
-    private Map<String, Integer> parseTimeCountCsv(byte[] csv) throws Exception {
+    private Map<String, Integer> parseTimeCountCsv(byte[] csv, ZoneOffset decodeZone) throws Exception {
         Map<String, Integer> result = new HashMap<>();
         CsvReader reader = new CsvReader(new ByteArrayInputStream(csv), java.nio.charset.StandardCharsets.UTF_8);
         reader.readHeaders();
         while (reader.readRecord()) {
             long millis = Long.parseLong(reader.get(0));
             int count = Integer.parseInt(reader.get(1));
-            String day = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+            String day = Instant.ofEpochMilli(millis).atZone(decodeZone).toLocalDate()
                     .format(DateTimeFormatter.ISO_LOCAL_DATE);
             result.put(day, count);
         }

--- a/src/test/java/drinkcounter/web/controllers/api/v2/ProfileApiControllerTest.java
+++ b/src/test/java/drinkcounter/web/controllers/api/v2/ProfileApiControllerTest.java
@@ -7,17 +7,21 @@ import drinkcounter.authentication.CurrentUser;
 import drinkcounter.model.Drink;
 import drinkcounter.model.User;
 import java.io.ByteArrayInputStream;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -47,6 +51,76 @@ public class ProfileApiControllerTest {
         when(currentUser.getUser()).thenReturn(user);
 
         controller = new ProfileApiController(drinkCounterService, userService, currentUser);
+    }
+
+    private TimeZone originalDefaultTimeZone;
+
+    @AfterEach
+    public void restoreDefaultTimeZone() {
+        if (originalDefaultTimeZone != null) {
+            TimeZone.setDefault(originalDefaultTimeZone);
+        }
+    }
+
+    // Issue #55: the bucketing offset here is currently hardcoded to 0 (UTC)
+    // -- see the commented-out session read in getDrinkHistory -- so the
+    // "Time" column must represent midnight UTC, not midnight in whatever
+    // zone the JVM happens to default to.
+    @Test
+    public void getDrinkHistoryTimeColumnRepresentsMidnightUtc_issue55() throws Exception {
+        originalDefaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+        Drink drink = new Drink();
+        drink.setTimeStamp(Instant.parse("2024-03-06T01:00:00Z")); // 2024-03-06 in UTC
+        user.drink(drink);
+
+        ResponseEntity<byte[]> response = controller.getDrinkHistory();
+
+        long millis = findMillisForUtcDay(response.getBody(), "2024-03-06");
+
+        long utcMidnightMillis = Instant.parse("2024-03-06T00:00:00Z").toEpochMilli();
+        assertEquals(utcMidnightMillis, millis,
+                "Time column should be midnight 2024-03-06 UTC, not midnight in the server's zone (America/Los_Angeles)");
+    }
+
+    // Issue #55: "today" must be decided in the same zone the bucketing
+    // uses (currently hardcoded UTC), not the server's systemDefault().
+    @Test
+    public void getDrinkHistoryTodayBucketUsesUtc_issue55() throws Exception {
+        originalDefaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles")); // UTC-8
+
+        // 2024-03-06T02:00:00Z is already 2024-03-05 in America/Los_Angeles.
+        Clock fixedClock = Clock.fixed(Instant.parse("2024-03-06T02:00:00Z"), ZoneOffset.UTC);
+        ReflectionTestUtils.setField(controller, "clock", fixedClock);
+
+        // no drinks: only the "today" bucket will be present
+
+        ResponseEntity<byte[]> response = controller.getDrinkHistory();
+
+        Map<String, Integer> countsByDay = parseTimeCountCsv(response.getBody());
+
+        assertTrue(countsByDay.containsKey("2024-03-06"),
+                "today's bucket should be 2024-03-06 (UTC date), not 2024-03-05 (server's America/Los_Angeles date)");
+    }
+
+    private long findMillisForUtcDay(byte[] csv, String targetDay) throws Exception {
+        CsvReader reader = new CsvReader(new ByteArrayInputStream(csv), java.nio.charset.StandardCharsets.UTF_8);
+        reader.readHeaders();
+        long result = -1;
+        while (reader.readRecord()) {
+            long millis = Long.parseLong(reader.get(0));
+            String dayUtc = Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate().toString();
+            if (dayUtc.equals(targetDay)) {
+                result = millis;
+            }
+        }
+        reader.close();
+        if (result == -1) {
+            throw new AssertionError("No row found for UTC day " + targetDay);
+        }
+        return result;
     }
 
     @Test
@@ -96,11 +170,15 @@ public class ProfileApiControllerTest {
 
         ResponseEntity<byte[]> response = controller.getDrinkHistory();
 
+        // The bucketing offset here is hardcoded to UTC, so the "Time"
+        // column is only meaningful when decoded in UTC too -- not the
+        // server's systemDefault(), which is fixed separately (see
+        // getDrinkHistoryTimeColumnRepresentsMidnightUtc_issue55).
         Map<String, Integer> countsByDay = parseTimeCountCsv(response.getBody());
         assertEquals(1, countsByDay.getOrDefault("2024-03-05", 0));
         assertEquals(1, countsByDay.getOrDefault("2024-03-06", 0));
 
-        String today = LocalDate.now(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String today = LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
         assertTrue(countsByDay.containsKey(today), "should always include today's bucket");
     }
 
@@ -111,7 +189,7 @@ public class ProfileApiControllerTest {
         while (reader.readRecord()) {
             long millis = Long.parseLong(reader.get(0));
             int count = Integer.parseInt(reader.get(1));
-            String day = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+            String day = Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate()
                     .format(DateTimeFormatter.ISO_LOCAL_DATE);
             result.put(day, count);
         }


### PR DESCRIPTION
## Summary

Fixes #55.

`APIController.drinkHistory` and `ProfileApiController.getDrinkHistory` bucketed a user's drinks into calendar days using the **client's** timezone offset, but then converted those day-bucket keys back into an epoch-millis "Time" value for the CSV export — and computed `"today"` — using the **server's** JVM zone (`ZoneId.systemDefault()`) instead. The two steps disagreed about which zone decides "what day is this," so the exported "Time" column didn't correspond to midnight in any single consistent zone.

- `APIController.drinkHistory`: reverse conversion and `"today"` now reuse `dtz`, the same client-offset `ZoneOffset` already used for bucketing.
- `ProfileApiController.getDrinkHistory`: same fix, applied against its (currently hardcoded-to-`0`) `dtz`, so it consistently stays anchored to UTC instead of drifting to whatever zone the JVM happens to default to.
- `"today"` in both is now computed via a new injectable `Clock` field (`clock.withZone(dtz)`) instead of an unmocked `LocalDate.now(ZoneId.systemDefault())`, making it deterministically testable.
- `grep -r "ZoneId.systemDefault\|systemDefault()" src/main/java` now returns no matches.

## Test plan

Written test-first (failing test → fix → passing), one commit's worth of increments per bug:

- [x] `APIControllerTest.drinkHistoryTimeColumnRepresentsMidnightInClientZone_issue55` — reproduces the issue's worked example (client UTC+2, server JVM `America/Los_Angeles`); failed pre-fix with the exact 10-hour discrepancy described in the issue, passes post-fix.
- [x] `APIControllerTest.drinkHistoryTodayBucketUsesClientZone_issue55` — deterministic via injected `Clock`; failed pre-fix (field didn't exist / wrong zone), passes post-fix.
- [x] `ProfileApiControllerTest.getDrinkHistoryTimeColumnRepresentsMidnightUtc_issue55` — same class of bug on the v2 endpoint; failed pre-fix, passes post-fix.
- [x] `ProfileApiControllerTest.getDrinkHistoryTodayBucketUsesUtc_issue55` — same, for `"today"`; failed pre-fix, passes post-fix.
- [x] Updated two pre-existing tests (`drinkHistoryBucketsDrinksByClientLocalDay`, `getDrinkHistoryBucketsDrinksByUtcDay`) whose CSV-decoding helpers previously used `ZoneId.systemDefault()` and were silently self-consistent with the bug (encode-wrong/decode-wrong canceled out); they now decode with the same zone production uses.
- [x] `mvn test` — full suite, 57/57 passing.

Frontend (`app/js/userhistorygraph.js`, `static/js/userhistorygraph.js`) already compensates for the client's own offset on top of the server's "Time" value, under the assumption that the server value is the true epoch of client-zone midnight — which this fix now makes true, so no frontend changes were needed. Not verified in a browser as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxGe5BuEYBu9DRzrFjDMqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxGe5BuEYBu9DRzrFjDMqs)_