### PR TITLE
Remove duplicate and stacked API requests in AngularJS controllers

### DIFF
--- a/src/main/resources/public/app/js/controllers/PartyCtrl.js
+++ b/src/main/resources/public/app/js/controllers/PartyCtrl.js
@@ -55,7 +55,8 @@ function PartyCtrl($scope, $routeParams, $timeout, RyyppyAPI) {
     });
 
     $scope.$on('drinkAdded', function () {
-        self.refreshParticipants();
+        self.endPolling();
+        self.startPolling();
     });
 }
 

--- a/src/main/resources/public/app/js/controllers/UserCtrl.js
+++ b/src/main/resources/public/app/js/controllers/UserCtrl.js
@@ -50,15 +50,13 @@ function UserCtrl($scope, $timeout, RyyppyAPI, Notify) {
         return moment(drink.timestamp);
     };
 
-    this.refreshProfile();
-    this.refreshOwnDrinks();
     this.refreshParties();
 
     this.startPolling();
 
     $scope.$on('drinkAdded', function () {
-        self.refreshProfile();
-        self.refreshOwnDrinks();
+        self.endPolling();
+        self.startPolling();
     });
 
     $scope.$on('$destroy', function () {
@@ -67,8 +65,8 @@ function UserCtrl($scope, $timeout, RyyppyAPI, Notify) {
 
     $scope.removeDrink = function (drink) {
         RyyppyAPI.removeDrink(drink.id, function () {
-            self.refreshProfile();
-            self.refreshOwnDrinks();
+            self.endPolling();
+            self.startPolling();
         });
     };
 }


### PR DESCRIPTION
UserCtrl fetched profile/drinks once on load, then startPolling's
immediate first tick re-fetched them, doubling the initial dashboard
load. Manual refreshes (drinkAdded, removeDrink, PartyCtrl's
drinkAdded) refetched without cancelling the pending poll timer, so a
manual refresh and the next scheduled poll could fire seconds apart.

Drop the redundant pre-poll calls and let the poll's own first tick
serve as the initial load, and have manual-refresh handlers cancel and
restart the poll timer instead of refetching directly, so the next
poll is a full interval away.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MtsPp6BBcqfNXyej6BiQre