### PR TITLE
Fix duplicate style.css fetch on login/terms/privacy pages

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -4,7 +4,6 @@
 <%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <t:master>
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
         <link rel="stylesheet" href="/static/vendor/jquery-tooltip/jquery.tooltip.css" type="text/css" media="screen" />
         <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/main/webapp/WEB-INF/jsp/privacy.jsp
+++ b/src/main/webapp/WEB-INF/jsp/privacy.jsp
@@ -3,7 +3,6 @@
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <t:master title="Tietosuojaseloste - Ryyppy.net">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
         <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <style>
             .privacy-policy {

--- a/src/main/webapp/WEB-INF/jsp/terms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/terms.jsp
@@ -3,7 +3,6 @@
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <t:master title="Käyttöehdot - Ryyppy.net">
     <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/style.css"/>" />
         <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
         <style>
             .terms {

--- a/src/main/webapp/WEB-INF/tags/master.tag
+++ b/src/main/webapp/WEB-INF/tags/master.tag
@@ -28,7 +28,7 @@
         <link href="https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext" rel="stylesheet" type="text/css" media="print" onload="this.media='all'" />
         <noscript><link href="https://fonts.googleapis.com/css?family=Rum+Raisin&subset=latin,latin-ext" rel="stylesheet" type="text/css" /></noscript>
 
-        <link rel="stylesheet" href="/static/css/style.css" type="text/css" media="screen" />
+        <link rel="stylesheet" href="<c:url value="/static/css/style.css"/>" type="text/css" media="screen" />
         <jsp:invoke fragment="customHead" />
     </head>
     <body>


### PR DESCRIPTION
master.tag rendered a hardcoded, unversioned <link> for style.css and
then invoked customHead, which login.jsp/terms.jsp/privacy.jsp also
used to link style.css (through <c:url>, resolving to the
content-hashed path). Both links ended up in the page, causing two
separate downloads of the same stylesheet.

Route master.tag's link through <c:url> so it gets the same
content-hash versioning as the rest of /static/css/**, and drop the
now-redundant per-page style.css links.

Fixes ryyppy-net/ryyppy.net#63

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EaPYxgBWtHKsoPV1Xftiik