### PR TITLE
Embed dashboard's initial data into app/index.jsp for faster first render

### DIFF
--- a/e2e/tests/ssr-initial-profile.spec.ts
+++ b/e2e/tests/ssr-initial-profile.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { makeTestUser, registerUser } from './helpers';
+
+test('the dashboard does not fetch the profile over the API on first load', async ({ page }) => {
+  // DefaultController.appIndex() now embeds the current user's profile into
+  // app/index.jsp as window.__INITIAL_PROFILE__, and UserCtrl.refreshProfile
+  // consumes it instead of calling GET /API/v2/profile on its first tick.
+  // This asserts that first XHR round-trip is actually gone, not just that
+  // the UI still renders correctly (which it would either way).
+  const profileRequests: string[] = [];
+  page.on('request', (request) => {
+    if (/\/API\/v2\/profile(\?|$)/.test(request.url()) && request.method() === 'GET') {
+      profileRequests.push(request.url());
+    }
+  });
+
+  const user = makeTestUser('ssr-profile');
+  await registerUser(page, user);
+
+  // registerUser already waits for the dashboard heading, i.e. for UserCtrl's
+  // first refreshProfile()/refreshParties() tick to have run.
+  expect(profileRequests).toEqual([]);
+
+  // The profile-derived UI (promille tile, sourced from window.__INITIAL_PROFILE__)
+  // should still have rendered correctly despite skipping the fetch.
+  const ownTile = page.locator('.drinker', { has: page.getByText(user.name) });
+  await expect(ownTile).toBeVisible();
+  await expect(ownTile.locator('p', { hasText: 'Promilleja' })).toBeVisible();
+
+  // window.__INITIAL_PROFILE__ is consumed-and-cleared on first use so later
+  // polling ticks fall back to the real API as before.
+  const initialProfileAfterLoad = await page.evaluate(() => (window as any).__INITIAL_PROFILE__);
+  expect(initialProfileAfterLoad).toBeNull();
+});

--- a/e2e/tests/ssr-initial-profile.spec.ts
+++ b/e2e/tests/ssr-initial-profile.spec.ts
@@ -1,21 +1,24 @@
 import { test, expect } from '@playwright/test';
 import { makeTestUser, registerUser } from './helpers';
 
-test('the dashboard does not fetch the profile, parties, or own drinks over the API on first load', async ({ page }) => {
+test('the dashboard does not fetch the profile, parties, own drinks, or drink-history graph data over the API on first load', async ({ page }) => {
   // DefaultController.appIndex() embeds the current user's profile, parties,
-  // and own drinks into app/index.jsp as window.__INITIAL_PROFILE__ /
-  // __INITIAL_PARTIES__ / __INITIAL_DRINKS__, and UserCtrl's
-  // refreshProfile/refreshParties/refreshOwnDrinks consume them instead of
-  // calling GET /API/v2/profile, /API/v2/parties, /API/v2/profile/drinks on
-  // their first tick. This asserts those first XHR round-trips are actually
-  // gone, not just that the UI still renders correctly (which it would
-  // either way).
+  // own drinks, and drink-history CSV into app/index.jsp as
+  // window.__INITIAL_PROFILE__ / __INITIAL_PARTIES__ / __INITIAL_DRINKS__ /
+  // __INITIAL_DRINK_HISTORY__, and UserCtrl's
+  // refreshProfile/refreshParties/refreshOwnDrinks plus
+  // UserHistoryGraph.update() (the promille-history bar chart) consume them
+  // instead of calling GET /API/v2/profile, /API/v2/parties,
+  // /API/v2/profile/drinks, /API/v2/profile/drink-history on their first
+  // tick. This asserts those first XHR round-trips are actually gone, not
+  // just that the UI still renders correctly (which it would either way).
   const skippableRequests: string[] = [];
   page.on('request', (request) => {
     const url = request.url();
     if (request.method() !== 'GET') return;
-    if (/\/API\/v2\/profile(\?|$)/.test(url)
+    if (/\/API\/v2\/profile\/drink-history(\?|$)/.test(url)
         || /\/API\/v2\/profile\/drinks(\?|$)/.test(url)
+        || /\/API\/v2\/profile(\?|$)/.test(url)
         || /\/API\/v2\/parties(\?|$)/.test(url)) {
       skippableRequests.push(url);
     }
@@ -26,20 +29,24 @@ test('the dashboard does not fetch the profile, parties, or own drinks over the 
 
   // registerUser already waits for the dashboard heading, i.e. for UserCtrl's
   // first refreshProfile()/refreshParties()/refreshOwnDrinks() tick to have run.
-  expect(skippableRequests).toEqual([]);
-
-  // The profile-derived UI (promille tile, sourced from window.__INITIAL_PROFILE__)
-  // should still have rendered correctly despite skipping the fetch.
   const ownTile = page.locator('.drinker', { has: page.getByText(user.name) });
   await expect(ownTile).toBeVisible();
   await expect(ownTile.locator('p', { hasText: 'Promilleja' })).toBeVisible();
 
+  // UserHistoryGraph is created via setTimeout(0) inside UserCtrl's
+  // applyProfile, so wait for its flot canvas to actually render before
+  // asserting no drink-history request fired.
+  await expect(page.locator('#historyGraph canvas').first()).toBeVisible();
+
+  expect(skippableRequests).toEqual([]);
+
   // Each window.__INITIAL_*__ blob is consumed-and-cleared on first use so
-  // later polling ticks fall back to the real API as before.
+  // later polling/refresh ticks fall back to the real API as before.
   const initialDataAfterLoad = await page.evaluate(() => ({
     profile: (window as any).__INITIAL_PROFILE__,
     parties: (window as any).__INITIAL_PARTIES__,
     drinks: (window as any).__INITIAL_DRINKS__,
+    drinkHistory: (window as any).__INITIAL_DRINK_HISTORY__,
   }));
-  expect(initialDataAfterLoad).toEqual({ profile: null, parties: null, drinks: null });
+  expect(initialDataAfterLoad).toEqual({ profile: null, parties: null, drinks: null, drinkHistory: null });
 });

--- a/e2e/tests/ssr-initial-profile.spec.ts
+++ b/e2e/tests/ssr-initial-profile.spec.ts
@@ -1,16 +1,23 @@
 import { test, expect } from '@playwright/test';
 import { makeTestUser, registerUser } from './helpers';
 
-test('the dashboard does not fetch the profile over the API on first load', async ({ page }) => {
-  // DefaultController.appIndex() now embeds the current user's profile into
-  // app/index.jsp as window.__INITIAL_PROFILE__, and UserCtrl.refreshProfile
-  // consumes it instead of calling GET /API/v2/profile on its first tick.
-  // This asserts that first XHR round-trip is actually gone, not just that
-  // the UI still renders correctly (which it would either way).
-  const profileRequests: string[] = [];
+test('the dashboard does not fetch the profile, parties, or own drinks over the API on first load', async ({ page }) => {
+  // DefaultController.appIndex() embeds the current user's profile, parties,
+  // and own drinks into app/index.jsp as window.__INITIAL_PROFILE__ /
+  // __INITIAL_PARTIES__ / __INITIAL_DRINKS__, and UserCtrl's
+  // refreshProfile/refreshParties/refreshOwnDrinks consume them instead of
+  // calling GET /API/v2/profile, /API/v2/parties, /API/v2/profile/drinks on
+  // their first tick. This asserts those first XHR round-trips are actually
+  // gone, not just that the UI still renders correctly (which it would
+  // either way).
+  const skippableRequests: string[] = [];
   page.on('request', (request) => {
-    if (/\/API\/v2\/profile(\?|$)/.test(request.url()) && request.method() === 'GET') {
-      profileRequests.push(request.url());
+    const url = request.url();
+    if (request.method() !== 'GET') return;
+    if (/\/API\/v2\/profile(\?|$)/.test(url)
+        || /\/API\/v2\/profile\/drinks(\?|$)/.test(url)
+        || /\/API\/v2\/parties(\?|$)/.test(url)) {
+      skippableRequests.push(url);
     }
   });
 
@@ -18,8 +25,8 @@ test('the dashboard does not fetch the profile over the API on first load', asyn
   await registerUser(page, user);
 
   // registerUser already waits for the dashboard heading, i.e. for UserCtrl's
-  // first refreshProfile()/refreshParties() tick to have run.
-  expect(profileRequests).toEqual([]);
+  // first refreshProfile()/refreshParties()/refreshOwnDrinks() tick to have run.
+  expect(skippableRequests).toEqual([]);
 
   // The profile-derived UI (promille tile, sourced from window.__INITIAL_PROFILE__)
   // should still have rendered correctly despite skipping the fetch.
@@ -27,8 +34,12 @@ test('the dashboard does not fetch the profile over the API on first load', asyn
   await expect(ownTile).toBeVisible();
   await expect(ownTile.locator('p', { hasText: 'Promilleja' })).toBeVisible();
 
-  // window.__INITIAL_PROFILE__ is consumed-and-cleared on first use so later
-  // polling ticks fall back to the real API as before.
-  const initialProfileAfterLoad = await page.evaluate(() => (window as any).__INITIAL_PROFILE__);
-  expect(initialProfileAfterLoad).toBeNull();
+  // Each window.__INITIAL_*__ blob is consumed-and-cleared on first use so
+  // later polling ticks fall back to the real API as before.
+  const initialDataAfterLoad = await page.evaluate(() => ({
+    profile: (window as any).__INITIAL_PROFILE__,
+    parties: (window as any).__INITIAL_PARTIES__,
+    drinks: (window as any).__INITIAL_DRINKS__,
+  }));
+  expect(initialDataAfterLoad).toEqual({ profile: null, parties: null, drinks: null });
 });

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -1,6 +1,11 @@
 package drinkcounter.web.controllers;
 
+import drinkcounter.authentication.CurrentUser;
+import drinkcounter.model.User;
+import drinkcounter.web.controllers.api.v2.SlopeService;
+import drinkcounter.web.controllers.api.v2.UserDTO;
 import org.springframework.core.io.Resource;
+import tools.jackson.databind.ObjectMapper;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -20,9 +25,13 @@ public class DefaultController {
     public static final String REDIRECT_TO_FRONTPAGE = "redirect:/app/index.html#/";
 
     private final ResourcePatternResolver resourcePatternResolver;
+    private final CurrentUser currentUser;
+    private final ObjectMapper objectMapper;
 
-    public DefaultController(ResourcePatternResolver resourcePatternResolver) {
+    public DefaultController(ResourcePatternResolver resourcePatternResolver, CurrentUser currentUser, ObjectMapper objectMapper) {
         this.resourcePatternResolver = resourcePatternResolver;
+        this.currentUser = currentUser;
+        this.objectMapper = objectMapper;
     }
 
     @GetMapping
@@ -37,7 +46,17 @@ public class DefaultController {
         // the comment in app/index.jsp. Read fresh on every request for now
         // (no caching yet).
         model.addAttribute("templates", loadPartialTemplates());
+        // Embed the current user's own profile (same shape as GET /API/v2/profile)
+        // so UserCtrl can skip its first fetch - see the comment in app/index.jsp.
+        model.addAttribute("initialProfile", objectMapper.writeValueAsString(loadInitialProfile()));
         return "app/index";
+    }
+
+    private UserDTO loadInitialProfile() {
+        User user = currentUser.getUser();
+        UserDTO userDTO = UserDTO.fromUser(user);
+        userDTO.setHistory(SlopeService.getSlopes(user));
+        return userDTO;
     }
 
     private Map<String, String> loadPartialTemplates() {

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -56,16 +56,8 @@ public class DefaultController {
         // the comment in app/index.jsp. Read fresh on every request for now
         // (no caching yet).
         model.addAttribute("templates", loadPartialTemplates());
-        // Embed the data UserCtrl (and the promille history graph it renders)
-        // fetches immediately on load - same shapes as GET /API/v2/profile,
-        // /API/v2/parties, /API/v2/profile/drinks and
-        // /API/v2/profile/drink-history - so it can skip those first fetches.
-        // Each is JSON-serialized then run through Spring's
-        // JavaScriptUtils.javaScriptEscape() for safe embedding as a
-        // single-quoted JS string literal - the JSP then wraps it as
-        // JSON.parse('...') rather than splicing it in as a raw object
-        // literal. See the comment in app/index.jsp for why (JSTL's usual
-        // fn:escapeXml is the wrong tool here).
+        // Dashboard data UserCtrl (and its promille history graph) would
+        // otherwise fetch over the API right after load - see app/index.jsp.
         model.addAttribute("initialProfile", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialProfile())));
         model.addAttribute("initialParties", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialParties())));
         model.addAttribute("initialDrinks", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialDrinks())));

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.JavaScriptUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -68,20 +69,21 @@ public class DefaultController {
     }
 
     /**
-     * Serializes to JSON safe to embed directly (unescaped) inside a JSP
-     * {@code <script>} block. JSTL's usual fn:escapeXml is the wrong tool
-     * here: it HTML-entity-encodes quotes, but a browser's HTML parser never
-     * decodes entities inside <script> text content, so an entity-encoded
-     * JSON string just fails to parse. Escaping "<" instead prevents the
-     * output from ever containing a literal "</script" that would close the
-     * tag early; U+2028/U+2029 are legal in JSON strings but illegal
-     * unescaped in a JS source, where a <script> block is parsed as one.
+     * Serializes to JSON, then escapes it for safe embedding as a single-quoted
+     * JS string literal inside a JSP {@code <script>} block - the JSP then
+     * wraps it as {@code JSON.parse('...')} rather than splicing it in as a
+     * raw object literal. JSTL's usual fn:escapeXml is the wrong tool here: it
+     * HTML-entity-encodes quotes, but a browser's HTML parser never decodes
+     * entities inside <script> text content, so an entity-encoded string just
+     * fails to parse. Spring's JavaScriptUtils.javaScriptEscape() is the
+     * correct tool for this exact context: besides the quote/backslash/control
+     * character escaping a JS string literal needs, it also hex-escapes "<"
+     * and ">" (preventing a literal "</script" from ever closing the tag
+     * early) and the JSON-legal-but-JS-source-illegal U+2028/U+2029 line
+     * separators.
      */
     private String toScriptSafeJson(Object value) {
-        return objectMapper.writeValueAsString(value)
-                .replace("<", "\\u003c")
-                .replace("\u2028", "\\u2028")
-                .replace("\u2029", "\\u2029");
+        return JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(value));
     }
 
     private UserDTO loadInitialProfile() {

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -60,30 +60,17 @@ public class DefaultController {
         // fetches immediately on load - same shapes as GET /API/v2/profile,
         // /API/v2/parties, /API/v2/profile/drinks and
         // /API/v2/profile/drink-history - so it can skip those first fetches.
-        // See the comment in app/index.jsp.
-        model.addAttribute("initialProfile", toScriptSafeJson(loadInitialProfile()));
-        model.addAttribute("initialParties", toScriptSafeJson(loadInitialParties()));
-        model.addAttribute("initialDrinks", toScriptSafeJson(loadInitialDrinks()));
-        model.addAttribute("initialDrinkHistory", toScriptSafeJson(loadInitialDrinkHistory()));
+        // Each is JSON-serialized then run through Spring's
+        // JavaScriptUtils.javaScriptEscape() for safe embedding as a
+        // single-quoted JS string literal - the JSP then wraps it as
+        // JSON.parse('...') rather than splicing it in as a raw object
+        // literal. See the comment in app/index.jsp for why (JSTL's usual
+        // fn:escapeXml is the wrong tool here).
+        model.addAttribute("initialProfile", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialProfile())));
+        model.addAttribute("initialParties", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialParties())));
+        model.addAttribute("initialDrinks", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialDrinks())));
+        model.addAttribute("initialDrinkHistory", JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(loadInitialDrinkHistory())));
         return "app/index";
-    }
-
-    /**
-     * Serializes to JSON, then escapes it for safe embedding as a single-quoted
-     * JS string literal inside a JSP {@code <script>} block - the JSP then
-     * wraps it as {@code JSON.parse('...')} rather than splicing it in as a
-     * raw object literal. JSTL's usual fn:escapeXml is the wrong tool here: it
-     * HTML-entity-encodes quotes, but a browser's HTML parser never decodes
-     * entities inside <script> text content, so an entity-encoded string just
-     * fails to parse. Spring's JavaScriptUtils.javaScriptEscape() is the
-     * correct tool for this exact context: besides the quote/backslash/control
-     * character escaping a JS string literal needs, it also hex-escapes "<"
-     * and ">" (preventing a literal "</script" from ever closing the tag
-     * early) and the JSON-legal-but-JS-source-illegal U+2028/U+2029 line
-     * separators.
-     */
-    private String toScriptSafeJson(Object value) {
-        return JavaScriptUtils.javaScriptEscape(objectMapper.writeValueAsString(value));
     }
 
     private UserDTO loadInitialProfile() {

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -5,6 +5,7 @@ import drinkcounter.model.Drink;
 import drinkcounter.model.Party;
 import drinkcounter.model.User;
 import drinkcounter.web.controllers.api.v2.DrinkDTO;
+import drinkcounter.web.controllers.api.v2.DrinkHistoryService;
 import drinkcounter.web.controllers.api.v2.ParticipantPreviewDTO;
 import drinkcounter.web.controllers.api.v2.PartyDTO;
 import drinkcounter.web.controllers.api.v2.SlopeService;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,12 +55,15 @@ public class DefaultController {
         // the comment in app/index.jsp. Read fresh on every request for now
         // (no caching yet).
         model.addAttribute("templates", loadPartialTemplates());
-        // Embed the data UserCtrl fetches immediately on load (same shapes as
-        // GET /API/v2/profile, /API/v2/parties and /API/v2/profile/drinks) so
-        // it can skip those first fetches - see the comment in app/index.jsp.
+        // Embed the data UserCtrl (and the promille history graph it renders)
+        // fetches immediately on load - same shapes as GET /API/v2/profile,
+        // /API/v2/parties, /API/v2/profile/drinks and
+        // /API/v2/profile/drink-history - so it can skip those first fetches.
+        // See the comment in app/index.jsp.
         model.addAttribute("initialProfile", toScriptSafeJson(loadInitialProfile()));
         model.addAttribute("initialParties", toScriptSafeJson(loadInitialParties()));
         model.addAttribute("initialDrinks", toScriptSafeJson(loadInitialDrinks()));
+        model.addAttribute("initialDrinkHistory", toScriptSafeJson(loadInitialDrinkHistory()));
         return "app/index";
     }
 
@@ -110,6 +115,14 @@ public class DefaultController {
             drinkDTOs.add(drinkDTO);
         }
         return drinkDTOs;
+    }
+
+    private String loadInitialDrinkHistory() {
+        try {
+            return DrinkHistoryService.buildCsv(currentUser.getUser().getDrinks(), Clock.systemUTC());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private Map<String, String> loadPartialTemplates() {

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -1,7 +1,12 @@
 package drinkcounter.web.controllers;
 
 import drinkcounter.authentication.CurrentUser;
+import drinkcounter.model.Drink;
+import drinkcounter.model.Party;
 import drinkcounter.model.User;
+import drinkcounter.web.controllers.api.v2.DrinkDTO;
+import drinkcounter.web.controllers.api.v2.ParticipantPreviewDTO;
+import drinkcounter.web.controllers.api.v2.PartyDTO;
 import drinkcounter.web.controllers.api.v2.SlopeService;
 import drinkcounter.web.controllers.api.v2.UserDTO;
 import org.springframework.core.io.Resource;
@@ -15,7 +20,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @RequestMapping("/")
@@ -46,9 +53,12 @@ public class DefaultController {
         // the comment in app/index.jsp. Read fresh on every request for now
         // (no caching yet).
         model.addAttribute("templates", loadPartialTemplates());
-        // Embed the current user's own profile (same shape as GET /API/v2/profile)
-        // so UserCtrl can skip its first fetch - see the comment in app/index.jsp.
+        // Embed the data UserCtrl fetches immediately on load (same shapes as
+        // GET /API/v2/profile, /API/v2/parties and /API/v2/profile/drinks) so
+        // it can skip those first fetches - see the comment in app/index.jsp.
         model.addAttribute("initialProfile", toScriptSafeJson(loadInitialProfile()));
+        model.addAttribute("initialParties", toScriptSafeJson(loadInitialParties()));
+        model.addAttribute("initialDrinks", toScriptSafeJson(loadInitialDrinks()));
         return "app/index";
     }
 
@@ -74,6 +84,32 @@ public class DefaultController {
         UserDTO userDTO = UserDTO.fromUser(user);
         userDTO.setHistory(SlopeService.getSlopes(user));
         return userDTO;
+    }
+
+    private List<PartyDTO> loadInitialParties() {
+        List<Party> parties = currentUser.getUser().getParties();
+        List<PartyDTO> partyDTOs = new ArrayList<>();
+        for (Party party : parties) {
+            PartyDTO partyDTO = PartyDTO.fromParty(party);
+            for (User participant : party.getParticipants()) {
+                partyDTO.addParticipant(ParticipantPreviewDTO.fromUser(participant));
+            }
+            partyDTOs.add(partyDTO);
+        }
+        return partyDTOs;
+    }
+
+    private List<DrinkDTO> loadInitialDrinks() {
+        List<Drink> drinks = currentUser.getUser().getDrinks();
+        List<DrinkDTO> drinkDTOs = new ArrayList<>();
+        for (Drink drink : drinks) {
+            DrinkDTO drinkDTO = new DrinkDTO();
+            drinkDTO.setId(drink.getId());
+            drinkDTO.setTimestamp(drink.getTimeStamp().toString());
+            drinkDTO.setAmountOfShots(drink.getAmountOfShots());
+            drinkDTOs.add(drinkDTO);
+        }
+        return drinkDTOs;
     }
 
     private Map<String, String> loadPartialTemplates() {

--- a/src/main/java/drinkcounter/web/controllers/DefaultController.java
+++ b/src/main/java/drinkcounter/web/controllers/DefaultController.java
@@ -48,8 +48,25 @@ public class DefaultController {
         model.addAttribute("templates", loadPartialTemplates());
         // Embed the current user's own profile (same shape as GET /API/v2/profile)
         // so UserCtrl can skip its first fetch - see the comment in app/index.jsp.
-        model.addAttribute("initialProfile", objectMapper.writeValueAsString(loadInitialProfile()));
+        model.addAttribute("initialProfile", toScriptSafeJson(loadInitialProfile()));
         return "app/index";
+    }
+
+    /**
+     * Serializes to JSON safe to embed directly (unescaped) inside a JSP
+     * {@code <script>} block. JSTL's usual fn:escapeXml is the wrong tool
+     * here: it HTML-entity-encodes quotes, but a browser's HTML parser never
+     * decodes entities inside <script> text content, so an entity-encoded
+     * JSON string just fails to parse. Escaping "<" instead prevents the
+     * output from ever containing a literal "</script" that would close the
+     * tag early; U+2028/U+2029 are legal in JSON strings but illegal
+     * unescaped in a JS source, where a <script> block is parsed as one.
+     */
+    private String toScriptSafeJson(Object value) {
+        return objectMapper.writeValueAsString(value)
+                .replace("<", "\\u003c")
+                .replace("\u2028", "\\u2028")
+                .replace("\u2029", "\\u2029");
     }
 
     private UserDTO loadInitialProfile() {

--- a/src/main/java/drinkcounter/web/controllers/api/v2/DrinkHistoryService.java
+++ b/src/main/java/drinkcounter/web/controllers/api/v2/DrinkHistoryService.java
@@ -1,0 +1,56 @@
+package drinkcounter.web.controllers.api.v2;
+
+import com.csvreader.CsvWriter;
+import drinkcounter.model.Drink;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the "Time,Drinks" per-day CSV that ProfileApiController.getDrinkHistory()
+ * serves and userhistorygraph.js parses, extracted so DefaultController can build
+ * the same data to embed on first render.
+ */
+public class DrinkHistoryService {
+    public static String buildCsv(List<Drink> drinks, Clock clock) throws IOException {
+        Map<String, Integer> drinksPerDay = new LinkedHashMap<String, Integer>();
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        double timezoneOffset = 0; // (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
+        ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int) (-timezoneOffset * 60));
+
+        for (Drink d : drinks) {
+            String s = d.getTimeStamp().atZone(dtz).format(format);
+
+            Integer i = 0;
+            if (drinksPerDay.containsKey(s))
+                i = drinksPerDay.get(s);
+            i += 1;
+            drinksPerDay.put(s, i);
+        }
+
+        String today = LocalDate.now(clock.withZone(dtz)).format(format);
+        if (!drinksPerDay.containsKey(today))
+            drinksPerDay.put(today, 0);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CsvWriter csvWriter = new CsvWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8), ',');
+        csvWriter.writeRecord(new String[]{"Time", "Drinks"});
+
+        for (Map.Entry<String, Integer> p : drinksPerDay.entrySet()) {
+            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(dtz).toInstant().toEpochMilli();
+            csvWriter.writeRecord(new String[]{Long.toString(millis), p.getValue().toString()});
+        }
+
+        csvWriter.close();
+        return baos.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
+++ b/src/main/java/drinkcounter/web/controllers/api/v2/ProfileApiController.java
@@ -4,22 +4,16 @@
  */
 package drinkcounter.web.controllers.api.v2;
 
-import com.csvreader.CsvWriter;
 import drinkcounter.DrinkCounterService;
 import drinkcounter.UserService;
 import drinkcounter.alcoholcalculator.AlcoholCalculator;
 import drinkcounter.authentication.CurrentUser;
 import drinkcounter.model.Drink;
 import drinkcounter.model.User;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import org.springframework.http.HttpHeaders;
@@ -109,42 +103,11 @@ public class ProfileApiController {
     @GetMapping("drink-history")
     public ResponseEntity<byte[]> getDrinkHistory() throws IOException{
         User user = currentUser.getUser();
-        List<Drink> drinks = user.getDrinks();
-
-        Map<String, Integer> drinksPerDay = new LinkedHashMap<String, Integer>();
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-        double timezoneOffset = 0; // (Double)session.getAttribute(AuthenticationController.TIMEZONEOFFSET);
-        ZoneOffset dtz = ZoneOffset.ofTotalSeconds((int)(-timezoneOffset * 60));
-
-        for (Drink d : drinks) {
-            String s = d.getTimeStamp().atZone(dtz).format(format);
-
-            Integer i = 0;
-            if (drinksPerDay.containsKey(s))
-                i = drinksPerDay.get(s);
-            i += 1;
-            drinksPerDay.put(s, i);
-        }
-
-        String today = LocalDate.now(clock.withZone(dtz)).format(format);
-        if (!drinksPerDay.containsKey(today))
-            drinksPerDay.put(today, 0);
+        String csv = DrinkHistoryService.buildCsv(user.getDrinks(), clock);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "text/plain;charset=utf-8");
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CsvWriter csvWriter = new CsvWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8), ',');
-        csvWriter.writeRecord(new String[]{"Time", "Drinks"});
-
-        for (Map.Entry<String, Integer> p : drinksPerDay.entrySet()) {
-            long millis = LocalDate.parse(p.getKey(), format).atStartOfDay(dtz).toInstant().toEpochMilli();
-            csvWriter.writeRecord(new String[]{Long.toString(millis), p.getValue().toString()});
-        }
-
-        csvWriter.close();
-        byte[] bytes = baos.toByteArray();
-        return new ResponseEntity<byte[]>(bytes, headers, HttpStatus.OK);
+        return new ResponseEntity<byte[]>(csv.getBytes(StandardCharsets.UTF_8), headers, HttpStatus.OK);
     }
 
     @ExceptionHandler(DateTimeParseException.class)

--- a/src/main/resources/public/app/js/controllers/UserCtrl.js
+++ b/src/main/resources/public/app/js/controllers/UserCtrl.js
@@ -4,18 +4,29 @@ function UserCtrl($scope, $timeout, RyyppyAPI, Notify) {
     var self = this;
     $scope.active = 'user';
 
-    this.refreshProfile = function () {
-        RyyppyAPI.getProfile(function (data) {
-            data.type = 'profile';
-            data.color = 1;
-            $scope.participants = [data];
+    function applyProfile(data) {
+        data.type = 'profile';
+        data.color = 1;
+        $scope.participants = [data];
 
-            setTimeout(function () {
-                var graph = new UserHistoryGraph($scope.participants[0], $("#historyGraph"));
-                graph.update();
-                graph.render();
-            }, 0);
-        });
+        setTimeout(function () {
+            var graph = new UserHistoryGraph($scope.participants[0], $("#historyGraph"));
+            graph.update();
+            graph.render();
+        }, 0);
+    }
+
+    this.refreshProfile = function () {
+        // The server embeds the profile into the page on load (see
+        // app/index.jsp) so the very first refresh can skip the XHR. Once
+        // used it's cleared so later polling ticks always hit the API.
+        if (window.__INITIAL_PROFILE__) {
+            var initialProfile = window.__INITIAL_PROFILE__;
+            window.__INITIAL_PROFILE__ = null;
+            applyProfile(initialProfile);
+            return;
+        }
+        RyyppyAPI.getProfile(applyProfile);
     };
 
     this.refreshParties = function () {

--- a/src/main/resources/public/app/js/controllers/UserCtrl.js
+++ b/src/main/resources/public/app/js/controllers/UserCtrl.js
@@ -30,12 +30,28 @@ function UserCtrl($scope, $timeout, RyyppyAPI, Notify) {
     };
 
     this.refreshParties = function () {
+        // See refreshProfile above - same skip-first-fetch pattern using data
+        // embedded by the server (app/index.jsp).
+        if (window.__INITIAL_PARTIES__) {
+            var initialParties = window.__INITIAL_PARTIES__;
+            window.__INITIAL_PARTIES__ = null;
+            $scope.parties = initialParties;
+            return;
+        }
         RyyppyAPI.getParties(function (data) {
             $scope.parties = data;
         });
     };
 
     this.refreshOwnDrinks = function () {
+        // See refreshProfile above - same skip-first-fetch pattern using data
+        // embedded by the server (app/index.jsp).
+        if (window.__INITIAL_DRINKS__) {
+            var initialDrinks = window.__INITIAL_DRINKS__;
+            window.__INITIAL_DRINKS__ = null;
+            $scope.drinks = initialDrinks;
+            return;
+        }
         RyyppyAPI.getOwnDrinks(function (data) {
             $scope.drinks = data;
         });

--- a/src/main/resources/public/app/js/userhistorygraph.js
+++ b/src/main/resources/public/app/js/userhistorygraph.js
@@ -27,6 +27,16 @@ function UserHistoryGraph(user, element) {
     this.update = function() {
         this.render();
 
+        // The server embeds this user's own drink-history CSV into the page
+        // on load (see app/index.jsp) so the very first update() can skip the
+        // XHR. Once used it's cleared so later refreshes always hit the API.
+        if (window.__INITIAL_DRINK_HISTORY__) {
+            var initialDrinkHistory = window.__INITIAL_DRINK_HISTORY__;
+            window.__INITIAL_DRINK_HISTORY__ = null;
+            that.gotData(initialDrinkHistory);
+            return;
+        }
+
         $.get(drinksUrl.replace('_userid_', this.user.id), function(data) {that.gotData(data);} );
     }
 

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -1,6 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8" isELIgnored="false"%>
 <%@taglib uri="jakarta.tags.core" prefix="c" %>
-<%@taglib uri="jakarta.tags.functions" prefix="fn" %>
 <!doctype html>
 <html lang="en" ng-app="ryyppy">
 <head>
@@ -37,12 +36,16 @@
         Embed the current user's own profile (DefaultController.appIndex(),
         same JSON shape as GET /API/v2/profile) so UserCtrl can skip its first
         fetch on load. Unlike the trusted-markup templates above, this JSON can
-        contain user-controlled strings (name, email), so it's HTML-escaped
-        with fn:escapeXml and re-parsed at runtime rather than embedded as raw
-        EL - that avoids both a premature </script> close and HTML injection.
+        contain user-controlled strings (name, email), so it can't be embedded
+        with plain unescaped EL as-is - but the usual JSTL fix for that,
+        fn:escapeXml, is the wrong tool here: a browser's HTML parser never
+        decodes entities inside <script> text content, so entity-escaped JSON
+        just fails to parse. DefaultController.toScriptSafeJson() does the
+        escaping that's actually needed for this context instead (only "<"
+        and the JS line separators), so ${...} is safe unescaped here.
     --%>
     <script>
-        window.__INITIAL_PROFILE__ = JSON.parse('${fn:escapeXml(initialProfile)}');
+        window.__INITIAL_PROFILE__ = ${initialProfile};
     </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -33,23 +33,27 @@
     </c:forEach>
 
     <%--
-        Embed the data UserCtrl fetches immediately on load
-        (DefaultController.appIndex(), same JSON shapes as GET /API/v2/profile,
-        /API/v2/parties and /API/v2/profile/drinks) so it can skip those first
-        fetches. Unlike the trusted-markup templates above, this JSON can
-        contain user-controlled strings (name, email, party name), so it can't
-        be embedded with plain unescaped EL as-is - but the usual JSTL fix for
+        Embed the data UserCtrl (and the promille history graph it renders)
+        fetches immediately on load (DefaultController.appIndex(), same JSON
+        shapes as GET /API/v2/profile, /API/v2/parties, /API/v2/profile/drinks
+        and /API/v2/profile/drink-history) so it can skip those first fetches.
+        Unlike the trusted-markup templates above, this data can contain
+        user-controlled strings (name, email, party name), so it can't be
+        embedded with plain unescaped EL as-is - but the usual JSTL fix for
         that, fn:escapeXml, is the wrong tool here: a browser's HTML parser
         never decodes entities inside <script> text content, so entity-escaped
-        JSON just fails to parse. DefaultController.toScriptSafeJson() does the
-        escaping that's actually needed for this context instead (only "<"
-        and the JS line separators), so ${...} is safe unescaped here.
+        JSON just fails to parse. Instead, DefaultController.toScriptSafeJson()
+        JSON-serializes each value and then runs it through Spring's
+        JavaScriptUtils.javaScriptEscape() - the purpose-built utility for
+        embedding a value as a JS string literal - so each ${...} below is a
+        safely-escaped string, wrapped here in single quotes and re-parsed via
+        JSON.parse() rather than spliced in as a raw object literal.
     --%>
     <script>
-        window.__INITIAL_PROFILE__ = ${initialProfile};
-        window.__INITIAL_PARTIES__ = ${initialParties};
-        window.__INITIAL_DRINKS__ = ${initialDrinks};
-        window.__INITIAL_DRINK_HISTORY__ = ${initialDrinkHistory};
+        window.__INITIAL_PROFILE__ = JSON.parse('${initialProfile}');
+        window.__INITIAL_PARTIES__ = JSON.parse('${initialParties}');
+        window.__INITIAL_DRINKS__ = JSON.parse('${initialDrinks}');
+        window.__INITIAL_DRINK_HISTORY__ = JSON.parse('${initialDrinkHistory}');
     </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -33,19 +33,22 @@
     </c:forEach>
 
     <%--
-        Embed the current user's own profile (DefaultController.appIndex(),
-        same JSON shape as GET /API/v2/profile) so UserCtrl can skip its first
-        fetch on load. Unlike the trusted-markup templates above, this JSON can
-        contain user-controlled strings (name, email), so it can't be embedded
-        with plain unescaped EL as-is - but the usual JSTL fix for that,
-        fn:escapeXml, is the wrong tool here: a browser's HTML parser never
-        decodes entities inside <script> text content, so entity-escaped JSON
-        just fails to parse. DefaultController.toScriptSafeJson() does the
+        Embed the data UserCtrl fetches immediately on load
+        (DefaultController.appIndex(), same JSON shapes as GET /API/v2/profile,
+        /API/v2/parties and /API/v2/profile/drinks) so it can skip those first
+        fetches. Unlike the trusted-markup templates above, this JSON can
+        contain user-controlled strings (name, email, party name), so it can't
+        be embedded with plain unescaped EL as-is - but the usual JSTL fix for
+        that, fn:escapeXml, is the wrong tool here: a browser's HTML parser
+        never decodes entities inside <script> text content, so entity-escaped
+        JSON just fails to parse. DefaultController.toScriptSafeJson() does the
         escaping that's actually needed for this context instead (only "<"
         and the JS line separators), so ${...} is safe unescaped here.
     --%>
     <script>
         window.__INITIAL_PROFILE__ = ${initialProfile};
+        window.__INITIAL_PARTIES__ = ${initialParties};
+        window.__INITIAL_DRINKS__ = ${initialDrinks};
     </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -49,6 +49,7 @@
         window.__INITIAL_PROFILE__ = ${initialProfile};
         window.__INITIAL_PARTIES__ = ${initialParties};
         window.__INITIAL_DRINKS__ = ${initialDrinks};
+        window.__INITIAL_DRINK_HISTORY__ = ${initialDrinkHistory};
     </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -33,21 +33,9 @@
     </c:forEach>
 
     <%--
-        Embed the data UserCtrl (and the promille history graph it renders)
-        fetches immediately on load (DefaultController.appIndex(), same JSON
-        shapes as GET /API/v2/profile, /API/v2/parties, /API/v2/profile/drinks
-        and /API/v2/profile/drink-history) so it can skip those first fetches.
-        Unlike the trusted-markup templates above, this data can contain
-        user-controlled strings (name, email, party name), so it can't be
-        embedded with plain unescaped EL as-is - but the usual JSTL fix for
-        that, fn:escapeXml, is the wrong tool here: a browser's HTML parser
-        never decodes entities inside <script> text content, so entity-escaped
-        JSON just fails to parse. Instead, DefaultController.toScriptSafeJson()
-        JSON-serializes each value and then runs it through Spring's
-        JavaScriptUtils.javaScriptEscape() - the purpose-built utility for
-        embedding a value as a JS string literal - so each ${...} below is a
-        safely-escaped string, wrapped here in single quotes and re-parsed via
-        JSON.parse() rather than spliced in as a raw object literal.
+        The current user's profile, parties, own drinks, and drink-history
+        graph data (DefaultController.appIndex()), so UserCtrl and the
+        promille history graph it renders can skip their first API fetch.
     --%>
     <script>
         window.__INITIAL_PROFILE__ = JSON.parse('${initialProfile}');

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -1,5 +1,6 @@
 <%@page contentType="text/html" pageEncoding="UTF-8" isELIgnored="false"%>
 <%@taglib uri="jakarta.tags.core" prefix="c" %>
+<%@taglib uri="jakarta.tags.functions" prefix="fn" %>
 <!doctype html>
 <html lang="en" ng-app="ryyppy">
 <head>
@@ -31,6 +32,18 @@
     <c:forEach var="template" items="${templates}">
         <script type="text/ng-template" id="${template.key}">${template.value}</script>
     </c:forEach>
+
+    <%--
+        Embed the current user's own profile (DefaultController.appIndex(),
+        same JSON shape as GET /API/v2/profile) so UserCtrl can skip its first
+        fetch on load. Unlike the trusted-markup templates above, this JSON can
+        contain user-controlled strings (name, email), so it's HTML-escaped
+        with fn:escapeXml and re-parsed at runtime rather than embedded as raw
+        EL - that avoids both a premature </script> close and HTML injection.
+    --%>
+    <script>
+        window.__INITIAL_PROFILE__ = JSON.parse('${fn:escapeXml(initialProfile)}');
+    </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>
     <script src="<c:url value="/app/js/app.js"/>"></script>


### PR DESCRIPTION
## Summary

Prototype for server-side rendering all of the dashboard's (`UserCtrl` + the promille-history graph it renders) load-time data, so AngularJS can use it on first render instead of firing its usual four immediate API calls.

- `DefaultController.appIndex()` now embeds, in the same shapes the v2 API returns them and built with the same DTO/service calls (`UserDTO.fromUser`/`SlopeService.getSlopes`, `PartyDTO.fromParty`/`ParticipantPreviewDTO.fromUser`, `DrinkDTO`, `DrinkHistoryService.buildCsv`):
  - `window.__INITIAL_PROFILE__` — same as `GET /API/v2/profile`
  - `window.__INITIAL_PARTIES__` — same as `GET /API/v2/parties`
  - `window.__INITIAL_DRINKS__` — same as `GET /API/v2/profile/drinks`
  - `window.__INITIAL_DRINK_HISTORY__` — same CSV as `GET /API/v2/profile/drink-history`
- `UserCtrl`'s `refreshProfile()`, `refreshParties()`, and `refreshOwnDrinks()`, plus `UserHistoryGraph.update()` (the promille bar chart `UserCtrl` renders right after the profile tile), each consume their respective embedded blob on the very first call instead of hitting the API, then clear it so the 60s polling loop / later refreshes still hit the real API afterwards.
- `ProfileApiController.getDrinkHistory()`'s CSV-building logic is extracted into `DrinkHistoryService.buildCsv()` (mirroring the existing `SlopeService` pattern) so `DefaultController` can build the identical CSV without duplicating the day-bucketing logic; the API endpoint itself is unchanged (same byte-for-byte output, still covered by the existing `ProfileApiControllerTest` timezone/bucketing tests).
- Escaping: each value is JSON-serialized via Spring's `ObjectMapper`, then escaped with Spring's own `org.springframework.web.util.JavaScriptUtils.javaScriptEscape()` (already on the classpath via `spring-boot-starter-web`, no new dependency) — the purpose-built utility for embedding a value as a JS string literal, handling quotes/backslashes/control characters plus hex-escaping `<`/`>` (so a literal `</script` can never close the tag early) and the JSON-legal-but-JS-source-illegal U+2028/U+2029 line separators. Since it escapes quotes, each value is embedded as `window.X = JSON.parse('${...}');` rather than spliced in as a raw object literal — the standard pattern for this. (An earlier iteration hand-escaped just `<`/U+2028/U+2029 and used a raw object literal; also considered JSTL's `fn:escapeXml`, which is the wrong tool since a browser's HTML parser never decodes entities inside `<script>` text content.)

## Test plan

- [x] `mvn compile` — backend compiles (had to switch `ObjectMapper`/Jackson imports to the `tools.jackson.*` packages Spring Boot 4.1.1's Jackson 3 uses)
- [x] `mvn test` — full unit test suite passes, including `ProfileApiControllerTest`'s drink-history timezone/bucketing tests against the extracted `DrinkHistoryService`
- [x] Playwright e2e test (`e2e/tests/ssr-initial-profile.spec.ts`) asserts none of `GET /API/v2/profile`, `/API/v2/parties`, `/API/v2/profile/drinks`, or `/API/v2/profile/drink-history` fire during registration + dashboard load (waiting for the history graph's canvas to actually render before checking), that each `window.__INITIAL_*__` blob is consumed-and-cleared, and that the promille tile still renders correctly from the embedded data
- [x] Full e2e suite (`npx playwright test`) — all 7 tests pass, re-verified after switching to the `JavaScriptUtils`/`JSON.parse` escaping approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCZ2Mh6fMM7oMcTFSAvkUL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCZ2Mh6fMM7oMcTFSAvkUL)_