### PR TITLE
Sort old UI parties list newest-first

### DIFF
--- a/src/main/java/drinkcounter/web/controllers/ui/UserController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/UserController.java
@@ -164,7 +164,7 @@ public class UserController {
         mav.setViewName("user");
         mav.addObject("user", user);
         mav.addObject("parties", user.getParties().stream()
-            .sorted(Comparator.comparing(Party::getStartTime))
+            .sorted(Comparator.comparing(Party::getStartTime).reversed())
             .collect(Collectors.toList())
         );
         


### PR DESCRIPTION
## Summary
- `UserController.userPage` sorted parties ascending by `startTime`, so the JSP-rendered old UI (`user.jsp`) listed the newest party at the bottom
- Sort is now reversed (newest first), matching the AngularJS UI's existing `orderBy:partySort:true` behavior

## Test plan
- [x] `mvn compile` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVQVm78cYcEojjKp9vyw9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVQVm78cYcEojjKp9vyw9Y)_