### PR TITLE
Add stale-while-revalidate service worker for Gravatar avatars

### DIFF
--- a/src/main/java/drinkcounter/web/WebConfiguration.java
+++ b/src/main/java/drinkcounter/web/WebConfiguration.java
@@ -53,12 +53,23 @@ public class WebConfiguration implements WebMvcConfigurer {
      * <link> tag), so they can't be versioned either. They change rarely, so
      * they get a week-long cache - short enough to roll out a replacement
      * without a URL change, unlike the year-long caches above.
+     *
+     * /sw.js (the Gravatar stale-while-revalidate service worker) must be
+     * served from the root path so its default scope covers the whole app,
+     * and explicitly with no-cache: browsers already re-check a service
+     * worker script periodically, but an HTTP cache sitting in front of that
+     * check would delay how quickly a new worker version can be picked up.
      */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         CacheControl oneYearImmutable = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic().immutable();
         CacheControl oneYear = CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic();
         CacheControl oneWeek = CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic();
+        CacheControl noCache = CacheControl.noCache();
+
+        registry.addResourceHandler("/sw.js")
+                .addResourceLocations("classpath:/public/")
+                .setCacheControl(noCache);
 
         registry.addResourceHandler("/webjars/**")
                 .addResourceLocations("classpath:/META-INF/resources/webjars/")

--- a/src/main/resources/public/sw.js
+++ b/src/main/resources/public/sw.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Stale-while-revalidate for Gravatar avatar images. These are requested as
+// <img> elements (no-cors mode, so the fetch() response is opaque - status 0,
+// body unreadable), and Gravatar sends a validating Cache-Control that forces
+// the browser to round-trip for a 304 on every load even though the image
+// rarely changes. Serving straight from Cache Storage skips that round trip;
+// the background fetch keeps the cached copy from going permanently stale.
+const GRAVATAR_CACHE = 'gravatar-v1';
+
+function isGravatarAvatarRequest(request) {
+    return request.method === 'GET' && request.url.indexOf('//www.gravatar.com/avatar/') !== -1;
+}
+
+self.addEventListener('install', function (event) {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', function (event) {
+    if (!isGravatarAvatarRequest(event.request)) {
+        return;
+    }
+
+    event.respondWith(
+        caches.open(GRAVATAR_CACHE).then(function (cache) {
+            return cache.match(event.request).then(function (cachedResponse) {
+                const revalidate = fetch(event.request.clone(), {cache: 'reload'})
+                    .then(function (networkResponse) {
+                        // Opaque cross-origin responses report status 0 / ok === false,
+                        // so we can't use response.ok to detect a real failure here.
+                        if (networkResponse.type === 'opaque' || networkResponse.ok) {
+                            cache.put(event.request, networkResponse.clone());
+                        }
+                        return networkResponse;
+                    })
+                    .catch(function () {
+                        return cachedResponse;
+                    });
+
+                return cachedResponse || revalidate;
+            });
+        })
+    );
+});

--- a/src/main/webapp/WEB-INF/jsp/app/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/app/index.jsp
@@ -20,6 +20,15 @@
     <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 <body>
+    <%-- Stale-while-revalidate cache for Gravatar avatar images, see sw.js. --%>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function () {
+                navigator.serviceWorker.register('/sw.js');
+            });
+        }
+    </script>
+
     <div ng-view></div>
 
     <%--


### PR DESCRIPTION
Gravatar responds with validating cache headers, so the browser round-trips
for a 304 on every avatar load even though the image rarely changes. The
service worker serves cached avatars from Cache Storage immediately and
revalidates in the background, skipping that round trip on repeat visits.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WM8a6vvqPmY3nYLTP8gQt