### PR TITLE
Remove unreferenced and broken /ui/addDrink handler

### DIFF
--- a/src/main/java/drinkcounter/web/controllers/ui/UserController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/UserController.java
@@ -129,15 +129,6 @@ public class UserController {
         return "redirect:user";
     }
 
-    @RequestMapping("/addDrink")
-    public String addDrink(HttpSession session, @RequestParam("id") String userId){
-        int id = Integer.parseInt(userId);
-        authenticationChecks.checkHighLevelRightsToUser(id);
-        
-        drinkCounterService.addDrink(id);
-        return "redirect:parties";
-    }
-    
     @RequestMapping("/addDrinkToDate")
     public String addDrinkToDate(HttpSession session, @RequestParam("userId") String userId, @RequestParam("date") String date){
         int id = Integer.parseInt(userId);


### PR DESCRIPTION
## What

Removes `UserController.addDrink()` (`/ui/addDrink`), which had no inbound references and redirected to `redirect:parties`, a mapping that does not exist. Anyone hitting the URL would have the drink recorded and then land on a 404.

## Why

Both UIs already add drinks through the API instead: the classic user button uses `/API/users/{id}/add-drink`, and the Angular app uses `/API/v2/...`. `DrinkCounterService.addDrink` itself is untouched — it still has plenty of other callers.

## Testing

- `mvn test` passes
- Verified no other code (JSP, JS, tests) references `/ui/addDrink`

Fixes #78

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133tnUX4tA6DbJFt6pQdCY1

---
_Generated by [Claude Code](https://claude.ai/code/session_0133tnUX4tA6DbJFt6pQdCY1)_