### PR TITLE
Remove unreferenced /ui/viewParty handler

### DIFF
--- a/src/main/java/drinkcounter/web/controllers/ui/PartyController.java
+++ b/src/main/java/drinkcounter/web/controllers/ui/PartyController.java
@@ -29,22 +29,6 @@ public class PartyController {
 
     @Autowired private AuthenticationChecks authenticationChecks;
 
-    @RequestMapping("/viewParty")
-    public ModelAndView viewParty(HttpSession session, @RequestParam("id") String partyId, @RequestParam(value="kick", required=false) String toKick){
-
-        int pid = Integer.parseInt(partyId);
-        authenticationChecks.checkRightsForParty(pid);
-        
-        if (toKick != null)
-            drinkCounterService.unlinkUserFromParty(Integer.parseInt(toKick), pid);
-        
-        ModelAndView mav = new ModelAndView();
-        mav.setViewName("party");
-        mav.addObject("party", drinkCounterService.getParty(pid));
-        mav.addObject("users", drinkCounterService.listUsersByParty(pid));
-        return mav;
-    }
-
     @RequestMapping("/party")
     public ModelAndView party(HttpSession session, @RequestParam("id") String partyId){
         int pid = Integer.parseInt(partyId);


### PR DESCRIPTION
## Summary
- Delete `PartyController.viewParty()` (`/ui/viewParty`), which duplicated `/ui/party` but rendered `party.jsp` with a subtly broken model
- `party.jsp`'s remove-drinker guard (`${participant.id != user.id}`) never matched on this route because `user` wasn't added to the model, so it offered the logged-in user a button to kick themselves out of their own party
- Its `kick` query parameter also performed a GET-triggered `unlinkUserFromParty` with no confirmation
- Nothing links to `/ui/viewParty` — the only other repo hit for `viewParty` is an unrelated `viewPartyUrl` variable in `user.jsp` that points at `party?id=...`

Fixes #77

## Test plan
- [x] `mvn compile` succeeds with no remaining references to the removed handler
- [x] Full Playwright e2e suite green (7/7) against the app running locally with the `viewParty` route removed
- [x] `/ui/party?id=N` continues to work in the e2e suite (party creation/drink-logging tests exercise it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5gQ7mWzeZ1WNe9HA21sJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5gQ7mWzeZ1WNe9HA21sJw)_