### PR TITLE
Fix flot resize crash on group graph dialog reopen

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/party.jsp
+++ b/src/main/webapp/WEB-INF/jsp/party.jsp
@@ -43,6 +43,9 @@
                     resizable: false,
                     open: function() {
                         graphDialogOpened();
+                    },
+                    close: function() {
+                        graphDialogClosed();
                     }
                 });
             });


### PR DESCRIPTION
## Summary

- `party.js` defines `graphDialogClosed()` (clears `RyyppyNet.graphVisible` and the redraw interval), but `party.jsp` never wired it to the `#groupGraphDialog` `close` event — only `open:` was configured.
- As a result, `graphVisible` stayed `true` after closing, so the two-minute `updateGroupGraph` interval kept redrawing a plot into a hidden container with no dimensions, and `jquery.flot.resize` threw on the next open.
- Added a `close:` handler calling `graphDialogClosed()`, mirroring the pattern already used in `user.jsp`'s drinks dialog.

Fixes https://github.com/ryyppy-net/ryyppy.net/issues/80

## Test plan

- [x] `mvn compile` (JSP compilation) succeeds with no errors.
- [ ] Manual/e2e verification (open → close → open the group graph dialog on `/ui/party?id=N`, confirm no console error and `RyyppyNet.graphVisible` tracks dialog state) — could not run the full stack in this sandbox (no Docker/Postgres available), will verify via CI/e2e on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJPfR4bFV2MB8NZh6d2vtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJPfR4bFV2MB8NZh6d2vtG)_