### PR TITLE
Skip rebuilding the drinker grid on every repaint to fix flot resize crash

### DIFF
--- a/src/main/resources/public/static/js/userbuttongrid.js
+++ b/src/main/resources/public/static/js/userbuttongrid.js
@@ -1,8 +1,18 @@
+function arraysEqual(a, b) {
+    if (a.length !== b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}
+
 function UserButtonGrid(target) {
     this.target = target;
     this.userButtons = [];
     this.users = undefined;
     this.onUserDrunk = undefined;
+    this.renderedUserIds = null;
+    this.renderedLayout = null;
 }
 
 UserButtonGrid.prototype.empty = function() {
@@ -14,9 +24,25 @@ UserButtonGrid.prototype.updateGrid = function() {
     if (this.users === undefined)
         return;
 
+    var layout = this.pivotLayoutIfNecessary(this.determineLayout(this.users.length));
+    var userIds = this.users.map(function(user) { return user.id; });
+
+    // repaint() (and so updateGrid()) runs on every window resize and every
+    // popup dialog open, not just when the participant list actually
+    // changes. Rebuilding the whole grid from scratch every time destroys
+    // and recreates each drinker's <td> and its .resize() binding (and its
+    // sparkline flot plot), and that churn corrupts the bundled legacy
+    // resize-event plugin bindings enough to crash jquery.flot.resize on a
+    // later dialog open (see #80). Skip the rebuild when nothing changed.
+    if (this.renderedUserIds != null &&
+        arraysEqual(this.renderedUserIds, userIds) &&
+        arraysEqual(this.renderedLayout, layout)) {
+        this.updateButtons();
+        return;
+    }
+
     this.empty();
 
-    var layout = this.pivotLayoutIfNecessary(this.determineLayout(this.users.length));
     RyyppyNet.layout = layout;
     var width = "" + (1 / layout[0] * 100) + "%;";
     var height = "" + (1 / layout[1] * 100) + "%;";
@@ -39,6 +65,9 @@ UserButtonGrid.prototype.updateGrid = function() {
             $('#row' + i).append(newElement);
         }
     }
+
+    this.renderedUserIds = userIds;
+    this.renderedLayout = layout;
 
     this.updateButtons();
 }


### PR DESCRIPTION
## Summary

Follow-up to #94, which wired `graphDialogClosed()` correctly (per #80's original "Do" section) but did **not** actually fix the reported crash — see https://github.com/ryyppy-net/ryyppy.net/issues/80#issuecomment-5644948739 for the full investigation.

The real cause: `repaint()` (`party.js`) runs on every window resize and on the group graph dialog's `open` handler, and `UserButtonGrid.updateGrid()` unconditionally did `$('#drinkers').html('')` and rebuilt the whole grid from scratch on every single call — destroying and recreating each drinker's `<td>` (and its own `.resize()` binding, plus its individual sparkline flot plot) even when the participant list and layout hadn't changed at all.

That churn corrupts the bookkeeping inside the bundled, ancient (2010) jQuery resize-event polyfill embedded in `jquery.flot.resize.js`, and its periodic 250ms poll then throws `Cannot read properties of undefined (reading 'w')` — the exact crash from #80. Critically, this reproduces **independently of the group graph dialog** — plain window resizing (with the dialog never touched) triggers it just as reliably.

## Fix

`UserButtonGrid.updateGrid()` now tracks the user ids and layout it last rendered and skips the destroy/rebuild when neither has changed, just refreshing the existing buttons' data instead (`updateButtons()`).

## Verification

Ran against a from-scratch local instance (real Postgres via `pg_ctlcluster`, `mvn spring-boot:run -Dspring-boot.run.arguments="--spring.docker.compose.enabled=false"`), scripted with Playwright:
- Original #80 repro (open → close → reopen the group graph dialog): 8/8 clean runs, no console errors, graph canvas renders on reopen.
- Pure window-resize repro (dialog never touched): clean, no errors (previously crashed reliably before this fix).
- Full existing e2e suite (`npm test` in `e2e/`): 7/7 passing.
- `mvn test`: passing.

Fixes https://github.com/ryyppy-net/ryyppy.net/issues/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJPfR4bFV2MB8NZh6d2vtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJPfR4bFV2MB8NZh6d2vtG)_