### PR TITLE
Add classic-UI helpers to the e2e suite

### DIFF
--- a/e2e/tests/classic-ui-flow.spec.ts
+++ b/e2e/tests/classic-ui-flow.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { makeTestUser, registerUser, loginClassic, createPartyClassic, addGuestToParty } from './helpers';
+
+test('a user can log in to the classic UI, create a party and add a guest drinker', async ({ page }) => {
+  const user = makeTestUser('classicflow');
+  await registerUser(page, user);
+  await page.goto('/logout');
+
+  await loginClassic(page, user);
+  await expect(page.locator('h1.topic', { hasText: user.name })).toBeVisible();
+
+  const partyName = `E2E Classic Party ${Date.now()}`;
+  await createPartyClassic(page, partyName);
+  await expect(page).toHaveURL(/\/ui\/party\?id=\d+/);
+
+  await addGuestToParty(page, { name: 'GuestHelper', sex: 'FEMALE', weight: '65' });
+  await expect(page.locator('#drinkers')).toContainText('GuestHelper');
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -66,10 +66,10 @@ export async function createParty(page: Page, partyName: string): Promise<void> 
 
 /**
  * Logs an already-registered user in and lands on the classic /ui/user
- * dashboard rather than the Angular one. WebSecurityConfiguration sets
- * .defaultSuccessUrl("/app/index.html", true) — the "true" forces the
- * Angular dashboard on login regardless of any saved request — so getting
- * to /ui/user takes an explicit navigation after login, not a redirect.
+ * dashboard rather than the Angular one. Login always redirects to the
+ * Angular dashboard (WebSecurityConfiguration's defaultSuccessUrl forces
+ * it regardless of any saved request), so this navigates to /ui/user
+ * explicitly afterward.
  */
 export async function loginClassic(page: Page, user: Pick<TestUser, 'name' | 'email' | 'password'>): Promise<void> {
   await loginUser(page, user);
@@ -104,14 +104,13 @@ export async function addGuestToParty(page: Page, guest: ClassicGuest): Promise<
 
   // #addDrinkerAccordion > h2 has two sections: index 0 is "add registered
   // user", index 1 is "add guest". The guest form reuses #drinkerName,
-  // #drinkerWeight and #submitButton from the registration page, so it must
-  // be opened first or a copied selector will target the wrong section.
+  // #drinkerWeight and #submitButton from the registration page, so a
+  // selector alone can't tell which section it targets.
   await page.locator('#addDrinkerAccordion > h2').nth(1).click();
 
   // The submit button starts disabled and is only re-enabled by
-  // checkDrinkerFields(false) on the field's own onkeyup handler. fill()
-  // sets values without firing keyup and leaves it stuck disabled, so type
-  // real keystrokes instead, exactly like registerUser does.
+  // checkDrinkerFields(false) on the field's own onkeyup handler, which
+  // fill() doesn't trigger — pressSequentially() types real keystrokes.
   await page.locator('#drinkerName').pressSequentially(guest.name);
   await page.selectOption('#drinkerSex', guest.sex);
   await page.locator('#drinkerWeight').pressSequentially(guest.weight);

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -63,3 +63,62 @@ export async function createParty(page: Page, partyName: string): Promise<void> 
 
   await expect(page).toHaveURL(/#\/party\/\d+/);
 }
+
+/**
+ * Logs an already-registered user in and lands on the classic /ui/user
+ * dashboard rather than the Angular one. WebSecurityConfiguration sets
+ * .defaultSuccessUrl("/app/index.html", true) — the "true" forces the
+ * Angular dashboard on login regardless of any saved request — so getting
+ * to /ui/user takes an explicit navigation after login, not a redirect.
+ */
+export async function loginClassic(page: Page, user: Pick<TestUser, 'name' | 'email' | 'password'>): Promise<void> {
+  await loginUser(page, user);
+  await page.goto('/ui/user', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('h1.topic', { hasText: user.name })).toBeVisible();
+}
+
+/** Creates a party from the classic /ui/user dashboard and waits for /ui/party?id=N. */
+export async function createPartyClassic(page: Page, partyName: string): Promise<void> {
+  // On /ui/user and /ui/party, every <a class="headerButtonA"> header wrapper
+  // measures 0x0 because the icon <div> inside it is floated, collapsing the
+  // inline anchor. The 42x42 icon div is what a user actually sees and clicks,
+  // and clicking it still works because the jQuery handlers are bound to the
+  // anchor and the click bubbles. Click #addPartyButton, not #addPartyButtonLink.
+  await page.click('#addPartyButton');
+  await page.fill('#nameInput', partyName);
+  await page.click('#addPartyDialog input[type="submit"]');
+
+  await expect(page).toHaveURL(/\/ui\/party\?id=\d+/);
+}
+
+export interface ClassicGuest {
+  name: string;
+  sex: 'MALE' | 'FEMALE';
+  weight: string;
+}
+
+/** Adds a guest drinker to a party from the classic /ui/party page's add-drinker dialog. */
+export async function addGuestToParty(page: Page, guest: ClassicGuest): Promise<void> {
+  // Same 0x0-anchor quirk as createPartyClassic: click the icon div, not the link.
+  await page.click('#addDrinkerButton');
+
+  // #addDrinkerAccordion > h2 has two sections: index 0 is "add registered
+  // user", index 1 is "add guest". The guest form reuses #drinkerName,
+  // #drinkerWeight and #submitButton from the registration page, so it must
+  // be opened first or a copied selector will target the wrong section.
+  await page.locator('#addDrinkerAccordion > h2').nth(1).click();
+
+  // The submit button starts disabled and is only re-enabled by
+  // checkDrinkerFields(false) on the field's own onkeyup handler. fill()
+  // sets values without firing keyup and leaves it stuck disabled, so type
+  // real keystrokes instead, exactly like registerUser does.
+  await page.locator('#drinkerName').pressSequentially(guest.name);
+  await page.selectOption('#drinkerSex', guest.sex);
+  await page.locator('#drinkerWeight').pressSequentially(guest.weight);
+  await page.click('#submitButton');
+
+  // The dialog submits via addAnonymousUser() and refreshes the grid through
+  // partyHost.update() rather than a page load, so wait on #drinkers directly
+  // instead of expecting a navigation.
+  await expect(page.locator('#drinkers')).toContainText(guest.name);
+}


### PR DESCRIPTION
## Summary

- Adds `loginClassic`, `createPartyClassic`, and `addGuestToParty` to `e2e/tests/helpers.ts`, encapsulating the classic-UI DOM quirks the issue documents: the login form always lands on the Angular dashboard regardless of a saved request, the header icon `<div>`s must be clicked rather than their collapsed `<a>` wrappers, the add-drinker dialog's guest section is the second accordion entry, and its submit button is only re-enabled by real keystrokes (`pressSequentially`, not `fill`).
- Adds `e2e/tests/classic-ui-flow.spec.ts` with the requested test: register → log out → log in via the classic UI → create a party → add a guest drinker → assert the guest shows up in `#drinkers`.
- `addDrinkAt` and the drink-seeding fixture are intentionally left out per the issue's suggestion to defer them to #85, where U5/U6 are their first consumers.

## Test plan

- [x] `mvn install` (app builds and boots cleanly)
- [x] Local PostgreSQL cluster running, app started with `--spring.docker.compose.enabled=false` against it
- [x] `npx playwright test -g "a user can log in to the classic UI"` — passes
- [x] Full e2e suite (`npx playwright test`) — 19/20 pass; the one failure (`passphrase.spec.ts`) reproduces only under 4-way parallel load and passes cleanly in isolation, unrelated to this change

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASwQYgztkyaTMNrPYmm4tD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASwQYgztkyaTMNrPYmm4tD)_