### PR TITLE
Add e2e coverage for the classic /ui/user dashboard

### DIFF
--- a/e2e/tests/classic-ui-user-dashboard.spec.ts
+++ b/e2e/tests/classic-ui-user-dashboard.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+import {
+  makeTestUser,
+  registerUser,
+  loginClassic,
+  createPartyClassic,
+  getClassicUserId,
+  addDrinkImmediatelyClassic,
+} from './helpers';
+
+test('U1: heading is the user name and #drinkers shows their button with a promille reading', async ({ page }) => {
+  const user = makeTestUser('dash-u1');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  await expect(page.locator('h1.topic')).toHaveText(user.name);
+  await expect(page.locator('#drinkers')).toContainText('0.00‰', { timeout: 10_000 });
+  await expect(page.locator('#drinkers')).toContainText('Paina tästä juodaksesi');
+});
+
+test('U2: party list shows each party name and formatted start time, newest first', async ({ page }) => {
+  const user = makeTestUser('dash-u2');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  const firstParty = `E2E U2 First ${Date.now()}`;
+  await createPartyClassic(page, firstParty);
+  await page.goto('/ui/user', { waitUntil: 'domcontentloaded' });
+
+  const secondParty = `E2E U2 Second ${Date.now()}`;
+  await createPartyClassic(page, secondParty);
+  await page.goto('/ui/user', { waitUntil: 'domcontentloaded' });
+
+  const parties = page.locator('.party');
+  await expect(parties).toHaveCount(2);
+  await expect(parties.nth(0)).toContainText(secondParty);
+  await expect(parties.nth(1)).toContainText(firstParty);
+  await expect(parties.nth(0).locator('#partyStartTime')).toContainText(/Alkamisaika \d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+});
+
+test('U3: add-party dialog creates a party and lands on its page', async ({ page }) => {
+  const user = makeTestUser('dash-u3');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  await page.click('#addPartyButton');
+  await expect(page.locator('#addPartyDialog')).toBeVisible();
+
+  const partyName = `E2E U3 Party ${Date.now()}`;
+  await page.fill('#nameInput', partyName);
+  await page.click('#addPartyDialog input[type="submit"]');
+
+  await expect(page).toHaveURL(/\/ui\/party\?id=\d+/);
+});
+
+test('U4: edit-profile dialog is prefilled and saving a new name redirects and updates the heading', async ({ page }) => {
+  const user = makeTestUser('dash-u4');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  await page.click('#configureButton');
+  await expect(page.locator('#configureDrinkerDialog')).toBeVisible();
+  await expect(page.locator('#drinkerName')).toHaveValue(user.name);
+  await expect(page.locator('#email')).toHaveValue(user.email);
+  await expect(page.locator('select[name="sex"]')).toHaveValue('MALE');
+
+  const newName = `${user.name} Renamed`;
+  await page.fill('#drinkerName', newName);
+  await page.click('#configureDrinkerDialog input[type="submit"]');
+
+  await expect(page).toHaveURL(/\/ui\/user/);
+  await expect(page.locator('h1.topic')).toHaveText(newName);
+});
+
+test('U5: drinks dialog lists existing drinks and removing one via confirm removes it', async ({ page }) => {
+  const user = makeTestUser('dash-u5');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  const userId = await getClassicUserId(page);
+  await addDrinkImmediatelyClassic(page, userId);
+
+  page.on('dialog', (dialog) => dialog.accept());
+
+  await page.click('#configureDrinksButton');
+  await expect(page.locator('#configureDrinksDialog')).toBeVisible();
+  await page.locator('#configureDrinksAccordion > h2').nth(1).click();
+
+  const drinkItems = page.locator('#drinksList li.drink');
+  await expect(drinkItems).toHaveCount(1);
+
+  await drinkItems.first().click();
+  await expect(page.locator('#drinksList')).toContainText('Ei lisättyjä juomia');
+});
+
+test('U6: adding a drink at a chosen past time via the datetimepicker adds it to the list', async ({ page }) => {
+  const user = makeTestUser('dash-u6');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  await page.click('#configureDrinksButton');
+  await expect(page.locator('#historyDrinkTime form.datetimepicker')).toBeVisible();
+
+  await page.click('#decreaseHours');
+  await page.click('#submitTime');
+
+  await expect(page).toHaveURL(/\/ui\/user/);
+
+  await page.click('#configureDrinksButton');
+  await page.locator('#configureDrinksAccordion > h2').nth(1).click();
+  await expect(page.locator('#drinksList li.drink')).toHaveCount(1);
+});
+
+test('U7: leaving a party drops it from the party list', async ({ page }) => {
+  const user = makeTestUser('dash-u7');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  const partyName = `E2E U7 Party ${Date.now()}`;
+  await createPartyClassic(page, partyName);
+  await page.goto('/ui/user', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('.party')).toContainText(partyName);
+
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.locator('.party', { has: page.getByText(partyName) }).locator('img[alt="sulje"]').click();
+
+  await page.goto('/ui/user', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('.party')).toHaveCount(0);
+});
+
+test('U8: clicking the drinker button adds a drink and changes the promille reading', async ({ page }) => {
+  const user = makeTestUser('dash-u8');
+  await registerUser(page, user);
+  await page.goto('/logout');
+  await loginClassic(page, user);
+
+  const userId = await getClassicUserId(page);
+  const promilleLocator = page.locator(`#info${userId} .details`).first();
+  await expect(promilleLocator).toHaveText('0.00‰', { timeout: 10_000 });
+
+  await addDrinkImmediatelyClassic(page, userId);
+
+  await expect(promilleLocator).not.toHaveText('0.00‰', { timeout: 10_000 });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -121,3 +121,23 @@ export async function addGuestToParty(page: Page, guest: ClassicGuest): Promise<
   // instead of expecting a navigation.
   await expect(page.locator('#drinkers')).toContainText(guest.name);
 }
+
+/** Reads the classic /ui/user dashboard's own userId, set as a global by user.jsp. */
+export async function getClassicUserId(page: Page): Promise<number> {
+  return page.evaluate(() => (window as any).userId);
+}
+
+/**
+ * Clicks a classic-UI drinker button and immediately accepts the drink via
+ * the edit-drink overlay, skipping the 5s undo countdown (see
+ * UserButton.showAdding/scheduleAddingDrink).
+ */
+export async function addDrinkImmediatelyClassic(page: Page, userId: number): Promise<void> {
+  await page.click(`#user${userId}`);
+  // The undo overlay's edit-button click handler is only bound once its
+  // 500ms fade-in animation completes, so a click before that lands on an
+  // unbound element and does nothing.
+  await page.waitForTimeout(700);
+  await page.click(`#editButton${userId}`);
+  await page.click(`#acceptButton${userId}`);
+}

--- a/src/main/webapp/WEB-INF/jsp/user.jsp
+++ b/src/main/webapp/WEB-INF/jsp/user.jsp
@@ -112,12 +112,13 @@
                 
                 
                 $('#submitTime').click(function() {
+                    var pad = function(n) { return n < 10 ? '0' + n : '' + n; };
                     var formattedTime = '{0}.{1}.{2} {3}:{4}'.format(
-                        picker.selectedTime.getDate(),
-                        picker.selectedTime.getMonth() + 1,
+                        pad(picker.selectedTime.getDate()),
+                        pad(picker.selectedTime.getMonth() + 1),
                         picker.selectedTime.getFullYear(),
-                        picker.selectedTime.getHours(),
-                        picker.selectedTime.getMinutes()
+                        pad(picker.selectedTime.getHours()),
+                        pad(picker.selectedTime.getMinutes())
                     );
                     $('#date').val(formattedTime);
                 });


### PR DESCRIPTION
## Summary

Closes #85. Adds a new `e2e/tests/classic-ui-user-dashboard.spec.ts` covering the eight scenarios from the issue:

- U1: heading is the user's name; `#drinkers` shows their button with a promille reading
- U2: party list shows each party's name and formatted start time, newest first
- U3: add-party dialog creates a party and redirects to `/ui/party?id=N`
- U4: edit-profile dialog is prefilled and saving a new name redirects to `/ui/user` with an updated heading
- U5: drinks dialog lists existing drinks; removing one via the confirm removes it
- U6: adding a drink at a chosen past time via the datetimepicker adds it to the list
- U7: leaving a party (x button + confirm) drops it from the party list
- U8: clicking the drinker button adds a drink and changes the promille reading

All tests click the classic-UI header icon `<div>`s (`#addPartyButton`, `#configureButton`, `#configureDrinksButton`), not the 0×0 `...Link` anchors, per the issue's dependency note.

Two small helpers were added to `e2e/tests/helpers.ts`: `getClassicUserId` and `addDrinkImmediatelyClassic` (clicks a drinker button and accepts the drink immediately via the edit overlay, skipping the 5s undo countdown).

While writing U6, found and fixed a real bug: `user.jsp`'s "add drink at date" form built its date string from the datetimepicker without zero-padding (e.g. `12.9.2026 17:44`), but the backend parses it with the strict pattern `dd.MM.yyyy HH:mm`, which requires two digits for day/month/hour. This made the feature fail for any single-digit day, month, or hour — i.e. most days of the year. Fixed by zero-padding in the click handler.

## Test plan

- [x] `npx playwright test tests/classic-ui-user-dashboard.spec.ts` — all 8 new tests pass
- [x] `npx playwright test --workers=1` — full e2e suite (28 tests) passes serially against a local Postgres instance
- [x] Verified the datetimepicker bug reproduces without the fix (`DateTimeParseException`) and is resolved with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRHkont6H3N8pLU5LBWbup

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRHkont6H3N8pLU5LBWbup)_