### PR TITLE
Add e2e coverage for the error page (fixes E1, E2 of #88)

### DIFF
--- a/e2e/tests/error-page.spec.ts
+++ b/e2e/tests/error-page.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { makeTestUser, registerUser, createParty } from './helpers';
+
+test('requesting a party you are not a participant of renders the error page', async ({ page, browser }) => {
+  const owner = makeTestUser('error-owner');
+  await registerUser(page, owner);
+
+  const partyName = `E2E Error Party ${Date.now()}`;
+  await createParty(page, partyName);
+  const partyId = page.url().match(/#\/party\/(\d+)/)?.[1];
+  expect(partyId).toBeTruthy();
+
+  const outsiderContext = await browser.newContext();
+  const outsiderPage = await outsiderContext.newPage();
+  const outsider = makeTestUser('error-outsider');
+  await registerUser(outsiderPage, outsider);
+
+  const response = await outsiderPage.goto(`/ui/party?id=${partyId}`, { waitUntil: 'domcontentloaded' });
+  expect(response?.status()).toBeGreaterThanOrEqual(400);
+  await expect(outsiderPage).toHaveTitle('Ryyppy.net - Virhe!');
+  await expect(outsiderPage.locator('h2')).toContainText('Tapahtui virhe!');
+
+  await outsiderContext.close();
+});
+
+test('an unknown /ui/... URL renders the error page', async ({ page }) => {
+  const user = makeTestUser('error-unknown-url');
+  await registerUser(page, user);
+
+  const response = await page.goto('/ui/does-not-exist', { waitUntil: 'domcontentloaded' });
+  expect(response?.status()).toBe(404);
+
+  await expect(page).toHaveTitle('Ryyppy.net - Virhe!');
+  await expect(page.locator('h2')).toContainText('Tapahtui virhe!');
+});


### PR DESCRIPTION
## Summary

Closes the remaining test gap in #88. T1 (legal pages, `page-loads.spec.ts`) and E3 (rejected login, `registration-login.spec.ts`) already existed on `main`; this adds the two error-page tests:

- **E1**: a user who requests a party they aren't a participant of gets the rendered error page (not a stack trace or whitelabel page).
- **E2**: an unknown `/ui/...` URL, requested by a logged-in user (so the security filter lets the request reach the dispatcher instead of redirecting to `/ui/login`), also renders the error page.

Both go through the real browser rather than an API request context, per the issue's note that `Accept: text/html` vs `Accept: */*` determines whether `error.jsp` or a JSON body comes back.

`LegalControllerTest`'s extension for `terms` (mentioned in the issue as "also worth doing") is left for when `terms.jsp` actually converts to Thymeleaf — it hasn't yet, so there's no `templates/terms.html` for that unit test to render.

## Test plan

- [x] `mvn test -Dtest=LegalControllerTest` — unchanged, still green
- [x] `npx playwright test error-page.spec.ts` — both new tests pass
- [x] `npx playwright test` (full suite) — all green except one pre-existing, unrelated flake in `party-classic.spec.ts` (`add-registered-user form enables its submit button...`), reproduced in isolation too; not touched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ug3EToYJuw9Aw87DfJhi8

---
_Generated by [Claude Code](https://claude.ai/code/session_013ug3EToYJuw9Aw87DfJhi8)_