### PR TITLE
Convert terms.jsp to Thymeleaf

### DIFF
--- a/e2e/tests/page-loads.spec.ts
+++ b/e2e/tests/page-loads.spec.ts
@@ -42,6 +42,7 @@ test('/ui/terms renders the terms of service for an anonymous visitor', async ({
 
   await expect(page).toHaveTitle('Käyttöehdot - Ryyppy.net');
   await expect(page.locator('h1', { hasText: 'Käyttöehdot' })).toBeVisible();
+  await expect(page.locator('a[href="/ui/privacy"]')).toBeVisible();
   await assertNoUnresolvedExpressions(page);
 });
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
     # an unconverted view name like "login" would be claimed by Thymeleaf
     # and blow up at render time instead of falling through to the JSP
     # resolver. List each view name here as its .jsp is converted.
-    view-names: privacy
+    view-names: privacy,terms
 
   messages:
     basename: messages,drinkcounter.version

--- a/src/main/resources/templates/terms.html
+++ b/src/main/resources/templates/terms.html
@@ -1,9 +1,16 @@
-<%@page contentType="text/html" pageEncoding="UTF-8" isELIgnored="false"%>
-<%@taglib uri="jakarta.tags.core" prefix="c" %>
-<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
-<t:master title="Käyttöehdot - Ryyppy.net">
-    <jsp:attribute name="customHead">
-        <link rel="stylesheet" type="text/css" href="<c:url value="/static/css/login.css"/>" />
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/master :: layout(~{::title}, ~{::#customHead}, ~{::#content})}">
+<!--
+    This document's own <html>/<head>/<body> are never rendered: th:replace
+    above swaps the whole element for the master layout fragment before it's
+    serialized. The markup below only exists so ~{::title}, ~{::#customHead}
+    and ~{::#content} have something to select from - see fragments/master.html.
+-->
+<head>
+    <title>Käyttöehdot - Ryyppy.net</title>
+
+    <div id="customHead" th:remove="tag">
+        <link rel="stylesheet" type="text/css" th:href="@{/static/css/login.css}" />
         <style>
             .terms {
                 background-color: #000000;
@@ -70,12 +77,13 @@
                 margin: 0;
             }
         </style>
-    </jsp:attribute>
-
-    <jsp:body>
+    </div>
+</head>
+<body>
+    <div id="content" th:remove="tag">
         <div id="logoContainer">
             <a href="/ui/login">
-                <img id="logo" src="<c:url value="/static/images/logo_ryyppy.png"/>" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
+                <img id="logo" th:src="@{/static/images/logo_ryyppy.png}" alt="Ryyppy.net" title="Ryyppy.net" style="max-width: 300px;" />
             </a>
         </div>
 
@@ -208,5 +216,6 @@
         <div class="back-link">
             <a href="/ui/login">&larr; Takaisin kirjautumissivulle</a>
         </div>
-    </jsp:body>
-</t:master>
+    </div>
+</body>
+</html>

--- a/src/test/java/drinkcounter/web/controllers/ui/LegalControllerTest.java
+++ b/src/test/java/drinkcounter/web/controllers/ui/LegalControllerTest.java
@@ -62,4 +62,16 @@ class LegalControllerTest {
         assertFalse(html.contains("${"), "unresolved Thymeleaf expression leaked into output");
         assertFalse(html.contains("customHead") , "the customHead/content wrapper divs should be removed by th:remove=\"tag\"");
     }
+
+    @Test
+    void termsTemplateRendersThroughMasterLayoutWithoutUnresolvedExpressions() {
+        String html = render("terms");
+
+        assertTrue(html.contains("<title>Käyttöehdot - Ryyppy.net</title>"), "title from the page wasn't projected into the master layout's <head>");
+        assertTrue(html.contains("Käyttöehdot"), "page body content missing");
+        assertTrue(html.contains("href=\"/static/css/login.css\""), "page-specific stylesheet from customHead missing");
+        assertTrue(html.contains("href=\"/static/css/style.css\""), "shared stylesheet from the master layout missing");
+        assertFalse(html.contains("${"), "unresolved Thymeleaf expression leaked into output");
+        assertFalse(html.contains("customHead") , "the customHead/content wrapper divs should be removed by th:remove=\"tag\"");
+    }
 }


### PR DESCRIPTION
## What changed

Two commits, per #104's gating requirement on #88:

1. **`e2e/tests/page-loads.spec.ts`** (fixes #88) — extends the existing `/ui/terms` smoke test to assert the page contains a link to `/ui/privacy`. Verified this assertion passes **against the current JSP** before touching any template code (ran `mvn spring-boot:run` against a local Postgres instance and `npx playwright test -g "renders the terms of service"` — green).

2. **`terms.jsp` → Thymeleaf** (fixes #104), following the `privacy.html` pattern from #74 exactly:
   - Added `src/main/resources/templates/terms.html`: `th:replace` on the root `<html>`, projecting `~{::title}`, `~{::#customHead}` and `~{::#content}` into `fragments/master.html`.
   - Added `terms` to `spring.thymeleaf.view-names` in `application.yml` (now `privacy,terms`).
   - Deleted `src/main/webapp/WEB-INF/jsp/terms.jsp`.
   - All three in the same commit, per #104: landing the template without the allow-list entry (or without deleting the `.jsp`) lets the old JSP keep serving the page silently (200, right title, right content) with nothing catching it.
   - Extended `LegalControllerTest` to render `terms` standalone alongside `privacy`, with the same assertions: title projected into the layout, body content present, page-specific stylesheet from `customHead` present, shared stylesheet from the master layout present, no unresolved `${` in the output, and the `customHead`/`content` wrapper divs removed by `th:remove="tag"`.

## Git rename detection

```
$ git diff -M --summary HEAD^ HEAD
 rename src/main/{webapp/WEB-INF/jsp/terms.jsp => resources/templates/terms.html} (89%)
```

Detected as a rename at 89% similarity (above git's 50% threshold, and above both the pilot's 87% and the 68% estimated for a mechanical conversion of this page in #104's notes).

## Verification performed

This sandbox has no Docker daemon, so I ran a local PostgreSQL 16 instance directly (creating the same `ryyppynet`/`ryyppynet` user/db the docker-compose init script creates) and started the app with `spring.docker.compose.enabled=false` instead of `docker compose up`. Everything else ran exactly as documented:

- ✅ `mvn test` — green, including the extended `LegalControllerTest` (3/3 tests pass).
- ✅ Full e2e suite (`cd e2e && npm install && npm test` equivalent, run with `SKIP_WEBSERVER=1` against the already-running app) — 32/32 passed on a clean re-run. On the first full-suite run, 3 unrelated tests (`classic-ui-user-dashboard.spec.ts` U1, and two `party-classic.spec.ts` tests) failed with timing/`NaN‰` issues under parallel load; re-running each individually passed cleanly, confirming these are flakes from this sandbox's resource constraints, not regressions from this change. `page-loads.spec.ts`'s `/ui/terms` and `/ui/privacy` tests passed in every run.
- ✅ Verified `/ui/terms` renders via Thymeleaf, not the old JSP: compared the rendered HTML structure against `/ui/privacy` (same master-layout structure, same fingerprinted static asset URLs e.g. `/static/css/login-f0665ba5172b8a8cef68d6338be48470.css`), confirmed no unresolved `${` in the output, and confirmed the title/body match the JSP's original copy.
- ✅ Confirmed `/ui/terms` still loads anonymously (curl with no session cookie → 200; it was already in `WebSecurityConfiguration`'s `permitAll` list, unchanged by this PR).
- ✅ `git diff -M --summary HEAD^ HEAD` reports the rename as shown above.
- ✅ CI (`ci.yml`) passed on this PR's head commit.
- ✅ Railway PR preview deployed successfully; hit `https://web-ryyppynet-pr-114.up.railway.app/ui/terms` directly — 200, correct title, `/ui/privacy` link present, no unresolved `${`.

Closes #104, closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbHZHqaNwTnTYuqwHU49MA