### PR TITLE
Convert newuser.jsp to Thymeleaf

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
     # an unconverted view name like "login" would be claimed by Thymeleaf
     # and blow up at render time instead of falling through to the JSP
     # resolver. List each view name here as its .jsp is converted.
-    view-names: privacy,terms
+    view-names: privacy,terms,newuser
 
   messages:
     basename: messages,drinkcounter.version

--- a/src/main/resources/templates/newuser.html
+++ b/src/main/resources/templates/newuser.html
@@ -1,25 +1,33 @@
-<%@page contentType="text/html" pageEncoding="UTF-8" isELIgnored="false"%>
-<%@taglib uri="jakarta.tags.core" prefix="c" %>
-<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
-<%@taglib uri="http://www.springframework.org/tags" prefix="spring"%>
-<t:master title="Uusi juoja">
-    <jsp:attribute name="customHead">
-        <script type="text/javascript" src="<c:url value="/static/js/common.js"/>"></script>
-        <script type="text/javascript" src="<c:url value="/static/js/drinkerchecks.js"/>"></script>
-        
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{fragments/master :: layout(~{::title}, ~{::#customHead}, ~{::#content})}">
+<!--
+    This document's own <html>/<head>/<body> are never rendered: th:replace
+    above swaps the whole element for the master layout fragment before it's
+    serialized. The markup below only exists so ~{::title}, ~{::#customHead}
+    and ~{::#content} have something to select from - see fragments/master.html.
+-->
+<head>
+    <title>Uusi juoja</title>
+
+    <div id="customHead" th:remove="tag">
+        <script type="text/javascript" th:src="@{/static/js/common.js}"></script>
+        <script type="text/javascript" th:src="@{/static/js/drinkerchecks.js}"></script>
+
         <link rel="stylesheet" href="/static/vendor/bootstrap/css/bootstrap.css"/>
-        <link rel="stylesheet" href="<c:url value="/app/css/app.css"/>"/>
+        <link rel="stylesheet" th:href="@{/app/css/app.css}"/>
 
         <script type="text/javascript">
             $(document).ready(function() {
                 $("#drinkerName").focus();
-                
+
                 $('.userField').live('keyup', function() { checkDrinkerFields(true); });
                 $('#email').live('keyup', function() { checkEmail($(this).val()); });
             });
         </script>
-    </jsp:attribute>
-    <jsp:body>
+    </div>
+</head>
+<body>
+    <div id="content" th:remove="tag">
         <div class="navbar">
             <div class="navbar-inner">
                 <span class="brand">Ryyppy.net</span>
@@ -34,9 +42,9 @@
                 <div class="offset1 span10">
                     <h1>Tervetuloa!</h1>
                     <p>Olet näemmä ensimmäistä kertaa tällä sivulla. Ole hyvä ja täytä allaolevat tiedot, niin aletaan ryyppäämään!</p>
-                    
+
                     <p>
-                        Sähköpostiosoitteellasi kaverit voivat kutsua sinut bileisiin. 
+                        Sähköpostiosoitteellasi kaverit voivat kutsua sinut bileisiin.
                         Jos käytät <a href="https://www.gravatar.com">Gravatar</a>-palvelua, Gravatar-profiilikuvasi näytetään kavereillesi ryyppy.netissä.
                         Me emme lähetä sinulle sähköpostia tai anna sähköpostiosoitettasi eteenpäin.
                     </p>
@@ -90,5 +98,6 @@
                 </div>
             </div>
         </div>
-    </jsp:body>
-</t:master>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #107

## Summary
- Add `src/main/resources/templates/newuser.html` following the `privacy.html` pattern (`th:replace` on root `<html>`, projecting title/customHead/content into `fragments/master.html`).
- Add `newuser` to `spring.thymeleaf.view-names` in `application.yml` (now `privacy,terms,newuser` after rebasing on the concurrently-merged `terms.jsp` conversion).
- Delete `src/main/webapp/WEB-INF/jsp/newuser.jsp`.

All three in one commit. No `spring:message`/model attributes on this page; the 3 `c:url` calls became `th:href`/`th:src`. DOM ids/classes used by `drinkerchecks.js` and the e2e helpers (`#drinkerName`, `#email`, `#emailCorrect`, `#sex`, `#drinkerWeight`, `#password`, `#submitButton`, `.userField`), the inline `onkeyup`/`onblur` handlers, and the `$('.userField').live(...)` call are kept byte-identical. jQuery 1.8.3 / `.live()` left untouched per the issue notes — not modernizing it in this PR.

## Verification
- `mvn test`: 60/60 green.
- Full Playwright e2e suite: green for everything relevant to this page, including `login-newuser.spec.ts` (N2, N3), `registration-login.spec.ts`, and `page-loads.spec.ts` (`/ui/newuser`).
- One unrelated test (`party-classic.spec.ts` "add-registered-user form enables its submit button...") intermittently fails/times out only when run with 2+ parallel Playwright workers in this container (browser session gets closed under load) and passes reliably every time it's run alone — confirmed 3x in isolation. Not touched by this change.
- Manually registered a user end-to-end via a scripted Playwright run typing into the fields (not `.fill()`): the live email check flips `#emailCorrect` to the "yes" image and `#submitButton` becomes enabled, matching current behavior.
- `/ui/newuser` still loads anonymously (curl without cookies returns 200; it remains in the `permitAll` list).
- `git diff -M --summary HEAD^ HEAD` and `git diff -M --summary origin/main...HEAD` both report `rename ... (81%)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyJZkfMEvXRYbsR3L8Mfpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyJZkfMEvXRYbsR3L8Mfpo)_