### PR TITLE
Convert app/index.jsp to Thymeleaf

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
     # an unconverted view name like "party" would be claimed by Thymeleaf
     # and blow up at render time instead of falling through to the JSP
     # resolver. List each view name here as its .jsp is converted.
-    view-names: privacy,terms,newuser,error,passphrase,login
+    view-names: privacy,terms,newuser,error,passphrase,login,app/index
 
   messages:
     basename: messages,drinkcounter.version

--- a/src/main/resources/templates/app/index.html
+++ b/src/main/resources/templates/app/index.html
@@ -1,7 +1,5 @@
-<%@page contentType="text/html" pageEncoding="UTF-8" isELIgnored="false"%>
-<%@taglib uri="jakarta.tags.core" prefix="c" %>
 <!doctype html>
-<html lang="en" ng-app="ryyppy">
+<html xmlns:th="http://www.thymeleaf.org" lang="en" ng-app="ryyppy">
 <head>
     <meta charset="utf-8">
     <title>Ryyppy.net</title>
@@ -9,7 +7,7 @@
     <link rel="stylesheet" href="/static/vendor/bootstrap/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="/static/vendor/font-awesome/font-awesome.css"/>
     <link rel="stylesheet" href="/webjars/pnotify/1.2.0/jquery.pnotify.default.css"/>
-    <link rel="stylesheet" href="<c:url value="/app/css/app.css"/>"/>
+    <link rel="stylesheet" th:href="@{/app/css/app.css}"/>
 
     <!-- media="print" + onload swap keeps this from blocking the synchronous
          <script> tags below on a slow/unreachable Google Fonts request. -->
@@ -22,45 +20,49 @@
 <body>
     <div ng-view></div>
 
-    <%--
+    <!--
         Pre-populate $templateCache with every route's template (loaded from
         app/partials/ by DefaultController.appIndex()) so Angular never
-        fetches one over XHR. ${...} is intentionally unescaped: trusted
-        server-side markup, not user input.
-    --%>
-    <c:forEach var="template" items="${templates}">
-        <script type="text/ng-template" id="${template.key}">${template.value}</script>
-    </c:forEach>
+        fetches one over XHR. Written with th:utext (unescaped): trusted
+        server-side markup, not user input - th:text/[[...]] would escape it
+        to visible &lt;div&gt; markup instead of rendering it.
+    -->
+    <script type="text/ng-template" th:each="template : ${templates}" th:id="${template.key}" th:utext="${template.value}"></script>
 
-    <%--
+    <!--
         The current user's profile, parties, own drinks, and drink-history
         graph data (DefaultController.appIndex()), so UserCtrl and the
         promille history graph it renders can skip their first API fetch.
-    --%>
-    <script>
-        window.__INITIAL_PROFILE__ = JSON.parse('${initialProfile}');
-        window.__INITIAL_PARTIES__ = JSON.parse('${initialParties}');
-        window.__INITIAL_DRINKS__ = JSON.parse('${initialDrinks}');
-        window.__INITIAL_DRINK_HISTORY__ = JSON.parse('${initialDrinkHistory}');
+        Written with [(...)] (unescaped inlining), not [[...]]: each value is
+        already JavaScript-escaped by JavaScriptUtils.javaScriptEscape() in
+        the controller and gets substituted into a single-quoted JS string
+        literal below - escaping it again here would corrupt JSON.parse()
+        and break the whole dashboard.
+    -->
+    <script th:inline="javascript">
+        window.__INITIAL_PROFILE__ = JSON.parse('[(${initialProfile})]');
+        window.__INITIAL_PARTIES__ = JSON.parse('[(${initialParties})]');
+        window.__INITIAL_DRINKS__ = JSON.parse('[(${initialDrinks})]');
+        window.__INITIAL_DRINK_HISTORY__ = JSON.parse('[(${initialDrinkHistory})]');
     </script>
 
     <script src="/static/vendor/angular/angular.min.js"></script>
-    <script src="<c:url value="/app/js/app.js"/>"></script>
-    <script src="<c:url value="/app/js/services.js"/>"></script>
+    <script th:src="@{/app/js/app.js}"></script>
+    <script th:src="@{/app/js/services.js}"></script>
 
     <script src="/static/vendor/moment/moment.min.js"></script>
 
-    <script src="<c:url value="/app/js/controllers/UserCtrl.js"/>"></script>
-    <script src="<c:url value="/app/js/controllers/ProfileSettingsCtrl.js"/>"></script>
-    <script src="<c:url value="/app/js/controllers/DrinkerCtrl.js"/>"></script>
-    <script src="<c:url value="/app/js/controllers/PartyCtrl.js"/>"></script>
-    <script src="<c:url value="/app/js/controllers/GeneralPartyAdminCtrl.js"/>"></script>
-    <script src="<c:url value="/app/js/controllers/PartyAdminCtrl.js"/>"></script>
+    <script th:src="@{/app/js/controllers/UserCtrl.js}"></script>
+    <script th:src="@{/app/js/controllers/ProfileSettingsCtrl.js}"></script>
+    <script th:src="@{/app/js/controllers/DrinkerCtrl.js}"></script>
+    <script th:src="@{/app/js/controllers/PartyCtrl.js}"></script>
+    <script th:src="@{/app/js/controllers/GeneralPartyAdminCtrl.js}"></script>
+    <script th:src="@{/app/js/controllers/PartyAdminCtrl.js}"></script>
 
-    <script src="<c:url value="/app/js/userhistorygraph.js"/>"></script>
+    <script th:src="@{/app/js/userhistorygraph.js}"></script>
 
-    <script src="<c:url value="/app/js/filters.js"/>"></script>
-    <script src="<c:url value="/app/js/directives.js"/>"></script>
+    <script th:src="@{/app/js/filters.js}"></script>
+    <script th:src="@{/app/js/directives.js}"></script>
 
     <script src="/webjars/jquery/1.8.3/jquery.min.js"></script>
     <script src="/webjars/pnotify/1.2.0/jquery.pnotify.js"></script>


### PR DESCRIPTION
## Summary

- Rewrites the AngularJS shell (`app/index.jsp`) as `src/main/resources/templates/app/index.html`, adds `app/index` to `spring.thymeleaf.view-names`, and deletes the old `.jsp` — all in one commit.
- The `$templateCache` loop uses `th:each` + `th:utext` (unescaped) so each partial's markup is written raw instead of HTML-escaped.
- The four bootstrap JSON blobs (`__INITIAL_PROFILE__`/`__INITIAL_PARTIES__`/`__INITIAL_DRINKS__`/`__INITIAL_DRINK_HISTORY__`) use `[(...)]` unescaped inlining rather than `[[...]]`, since `JavaScriptUtils.javaScriptEscape()` in `DefaultController.appIndex()` already escapes them once — a second escape would corrupt `JSON.parse()` and break the whole dashboard.
- All 12 `c:url` asset paths converted to `th:href`/`th:src`.

## Verification

- `mvn test`: 63/63 green.
- Full Playwright suite (`--workers=1`, per the flakiness note in the task instructions): 35/35 green. `ssr-initial-profile.spec.ts` (asserts the four first-load XHRs do **not** fire, proving the JSON blobs still parse) passes.
- A run with default (4) workers hit the same single-test flake on `party-classic.spec.ts:20` (unrelated to this page — classic party-UI email-lookup form) that the task notes describe for this environment; it passes in isolation and under `--workers=1`.
- Manual browser check via Playwright: no page errors, promille history graph renders, and navigating between `#/` and `#/profile-settings` issues no XHR for a partial. The only console errors observed are `net::ERR_CONNECTION_RESET` for external Google Fonts/GSI/Gravatar requests, unrelated to this change and blocked only because this sandbox has no outbound internet access to those hosts.
- `/app/index.html` still requires an authenticated session (unchanged `WebSecurityConfiguration`).
- `git diff -M --summary origin/main...HEAD` reports a rename at exactly 50% similarity, so this merges as a single squash commit per the issue's decision rule.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3nfcEK2EnnGUXPjC5m3sW

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3nfcEK2EnnGUXPjC5m3sW)_