### PR TITLE
Replace custom resource filtering with Spring Boot's native build-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,18 +31,19 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>
                     <!--
-                        Generates META-INF/build-info.properties, which Spring Boot's
-                        ProjectInfoAutoConfiguration picks up as a BuildProperties bean
-                        (see GlobalControllerAdvice). Bound to generate-resources rather
-                        than the goal's default prepare-package phase so it also runs
-                        under mvn spring-boot:run, which never reaches prepare-package.
+                        Generates META-INF/build-info.properties (default phase:
+                        generate-resources, so this also runs under mvn
+                        spring-boot:run), which Spring Boot's ProjectInfoAutoConfiguration
+                        picks up as a BuildProperties bean (see GlobalControllerAdvice).
+                        Running the app straight from an IDE without going through this
+                        Maven build skips it, so that bean - and ${applicationVersion} -
+                        stays absent there.
                     -->
                     <execution>
                         <id>build-info</id>
                         <goals>
                             <goal>build-info</goal>
                         </goals>
-                        <phase>generate-resources</phase>
                     </execution>
                     <execution>
                         <id>process-aot</id>

--- a/pom.xml
+++ b/pom.xml
@@ -25,42 +25,25 @@
     </properties>
     <build>
         <finalName>${project.artifactId}</finalName>
-        <!--
-            spring-boot-starter-parent only filters resources matching
-            **/application*.{yml,yaml,properties}, so drinkcounter/version.properties
-            (application.version=@project.version@, looked up via the
-            drinkcounter.version message bundle - see spring.messages.basename in
-            application.yml) was never actually filtered: it rendered the literal
-            "@project.version@" in every packaged build, not just under
-            mvn spring-boot:run. Redeclaring the parent's split here, with this file
-            added to the filtered side, fixes that.
-        -->
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-                <includes>
-                    <include>**/application*.yml</include>
-                    <include>**/application*.yaml</include>
-                    <include>**/application*.properties</include>
-                    <include>drinkcounter/version.properties</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-                <excludes>
-                    <exclude>**/application*.yml</exclude>
-                    <exclude>**/application*.yaml</exclude>
-                    <exclude>**/application*.properties</exclude>
-                    <exclude>drinkcounter/version.properties</exclude>
-                </excludes>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>
+                    <!--
+                        Generates META-INF/build-info.properties, which Spring Boot's
+                        ProjectInfoAutoConfiguration picks up as a BuildProperties bean
+                        (see GlobalControllerAdvice). Bound to generate-resources rather
+                        than the goal's default prepare-package phase so it also runs
+                        under mvn spring-boot:run, which never reaches prepare-package.
+                    -->
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
                     <execution>
                         <id>process-aot</id>
                         <goals>

--- a/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
+++ b/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
@@ -19,7 +19,7 @@ public class GlobalControllerAdvice {
     private final BuildProperties buildProperties;
 
     @Autowired
-    public GlobalControllerAdvice(ClientRegistrationRepository clientRegistrationRepository, BuildProperties buildProperties) {
+    public GlobalControllerAdvice(ClientRegistrationRepository clientRegistrationRepository, @Autowired(required = false) BuildProperties buildProperties) {
         this.clientRegistrationRepository = clientRegistrationRepository;
         this.buildProperties = buildProperties;
     }
@@ -27,12 +27,14 @@ public class GlobalControllerAdvice {
     /**
      * The app version, sourced from the BuildProperties bean that Spring Boot's
      * ProjectInfoAutoConfiguration derives from META-INF/build-info.properties
-     * (see the spring-boot-maven-plugin build-info execution in pom.xml).
+     * (see the spring-boot-maven-plugin build-info execution in pom.xml). Not
+     * generated when the app is run straight from an IDE without going
+     * through that Maven build, so this is null in that case.
      * Available in templates as ${applicationVersion}
      */
     @ModelAttribute("applicationVersion")
     public String applicationVersion() {
-        return buildProperties.getVersion();
+        return buildProperties == null ? null : buildProperties.getVersion();
     }
 
     /**

--- a/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
+++ b/src/main/java/drinkcounter/web/GlobalControllerAdvice.java
@@ -3,6 +3,7 @@ package drinkcounter.web;
 import drinkcounter.authentication.relay.Origins;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -15,10 +16,23 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 public class GlobalControllerAdvice {
 
     private final ClientRegistrationRepository clientRegistrationRepository;
+    private final BuildProperties buildProperties;
 
     @Autowired
-    public GlobalControllerAdvice(ClientRegistrationRepository clientRegistrationRepository) {
+    public GlobalControllerAdvice(ClientRegistrationRepository clientRegistrationRepository, BuildProperties buildProperties) {
         this.clientRegistrationRepository = clientRegistrationRepository;
+        this.buildProperties = buildProperties;
+    }
+
+    /**
+     * The app version, sourced from the BuildProperties bean that Spring Boot's
+     * ProjectInfoAutoConfiguration derives from META-INF/build-info.properties
+     * (see the spring-boot-maven-plugin build-info execution in pom.xml).
+     * Available in templates as ${applicationVersion}
+     */
+    @ModelAttribute("applicationVersion")
+    public String applicationVersion() {
+        return buildProperties.getVersion();
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ spring:
     baseline-on-migrate: true
     baseline-version: 1
   messages:
-    basename: messages,drinkcounter.version
+    basename: messages
   docker:
     compose:
       file: docker/docker-compose.yml
@@ -55,5 +55,3 @@ server:
         # (spring.session.timeout). Match it here so the cookie actually
         # outlives a restart.
         max-age: 365d
-application:
-  version: "@project.version@"

--- a/src/main/resources/drinkcounter/version.properties
+++ b/src/main/resources/drinkcounter/version.properties
@@ -1,1 +1,0 @@
-application.version=@project.version@

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,9 @@
+# Deliberately empty. All translations live in messages_fi.properties (the
+# app's default locale) and messages_en.properties - there's no fi/en-agnostic
+# root bundle. This file still needs to exist because Spring Boot's
+# MessageSourceAutoConfiguration only activates a MessageSource bean if it can
+# find a literal "<basename>.properties" resource on the classpath; locale
+# variants like messages_fi.properties don't satisfy that check on their own.
+# Without this file (or some other basename with a matching root file), the
+# whole #{...} message mechanism silently falls back to none, and every
+# lookup renders as "??code_locale??".

--- a/src/main/resources/templates/fragments/master.html
+++ b/src/main/resources/templates/fragments/master.html
@@ -13,7 +13,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
         <!-- Build version marker, formerly a JSP comment in master.tag -->
-        <meta name="ryyppy-net-version" th:content="#{application.version}" />
+        <meta name="ryyppy-net-version" th:content="${applicationVersion}" />
 
         <title th:replace="${title}">Ryyppy.net</title>
 

--- a/src/test/java/drinkcounter/web/controllers/ui/ErrorTemplateTest.java
+++ b/src/test/java/drinkcounter/web/controllers/ui/ErrorTemplateTest.java
@@ -32,7 +32,7 @@ class ErrorTemplateTest {
         resolver.setCharacterEncoding("UTF-8");
 
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-        messageSource.setBasenames("messages", "drinkcounter.version");
+        messageSource.setBasenames("messages");
         messageSource.setDefaultEncoding("UTF-8");
 
         SpringTemplateEngine engine = new SpringTemplateEngine();

--- a/src/test/java/drinkcounter/web/controllers/ui/LoginTemplateTest.java
+++ b/src/test/java/drinkcounter/web/controllers/ui/LoginTemplateTest.java
@@ -34,7 +34,7 @@ class LoginTemplateTest {
         resolver.setCharacterEncoding("UTF-8");
 
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-        messageSource.setBasenames("messages", "drinkcounter.version");
+        messageSource.setBasenames("messages");
         messageSource.setDefaultEncoding("UTF-8");
 
         SpringTemplateEngine engine = new SpringTemplateEngine();

--- a/src/test/java/drinkcounter/web/controllers/ui/PartyTemplateTest.java
+++ b/src/test/java/drinkcounter/web/controllers/ui/PartyTemplateTest.java
@@ -44,7 +44,7 @@ class PartyTemplateTest {
         resolver.setCharacterEncoding("UTF-8");
 
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-        messageSource.setBasenames("messages", "drinkcounter.version");
+        messageSource.setBasenames("messages");
         messageSource.setDefaultEncoding("UTF-8");
 
         SpringTemplateEngine engine = new SpringTemplateEngine();


### PR DESCRIPTION
## Summary

- Replace the hand-rolled Maven `<resources>` split (filtering `drinkcounter/version.properties` alongside `application*.yml` just to substitute `@project.version@`) with `spring-boot-maven-plugin`'s native `build-info` goal, which generates `META-INF/build-info.properties`.
- Spring Boot auto-configures that into a `BuildProperties` bean; `GlobalControllerAdvice` exposes it as `${applicationVersion}` to all views, and `master.html` reads it directly instead of via the `drinkcounter.version` message bundle.
- `BuildProperties` injection is optional (`@Autowired(required = false)`, null-checked) since the bean is absent if the app is launched by running the main class directly from an IDE without going through the Maven build.
- Removed `version.properties`, the now-redundant `application.version` property in `application.yml`, and the `drinkcounter.version` messages basename entry (updated the three template-rendering tests accordingly).

## Test plan

- [x] `mvn test` (full suite) passes
- [x] `mvn spring-boot:run` against a local PostgreSQL instance renders `<meta name="ryyppy-net-version" content="3.1.5-SNAPSHOT" />` correctly
- [x] Verified the app still starts cleanly under `mvn spring-boot:run` when `build-info.properties` is absent (optional bean injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDXc1QAReJHVkaugs37NF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvDXc1QAReJHVkaugs37NF)_