### PR TITLE
Convert packaging from war to jar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ mvn spring-boot:run
 # Run tests
 mvn test
 
-# Build WAR file
+# Build jar file
 mvn install
 
 # Package specific version (updates pom.xml version)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Google login button will automatically appear on the login page when valid c
 ## Release
 1. Update version number in pom.xml
 2. Make a git TAG with the version number
-3. Run `mvn install` to build the application .war file
+3. Run `mvn install` to build the application .jar file
 
 ## Configure and run on server
 Set configuration using environment variables:
@@ -57,8 +57,8 @@ Set configuration using environment variables:
 * GOOGLE_CLIENT_ID - (Optional) Google OAuth2 client ID to enable Google login
 * GOOGLE_CLIENT_SECRET - (Optional) Google OAuth2 client secret to enable Google login
 
-1. Copy `ryyppynet-<version>.war` to server
-3. Run application `java -jar ryyppynet-<version>.war`
+1. Copy `target/ryyppynet.jar` to server
+3. Run application `java -jar ryyppynet.jar`
 
 ### Railway
 
@@ -69,14 +69,26 @@ pins the JDK to 25 and sets
 `mvn package` — which also runs Spring Boot's own AOT processing
 (`process-aot`, wired into `pom.xml`; generates ahead-of-time bean
 definitions so the context doesn't have to reflect over annotations at
-boot) — then trains a JDK AOT cache (`target/app.aot`, JEP 483/514) against
-an in-memory HSQLDB, regenerated every build, best-effort (a failed
-training run just skips the cache, build still succeeds). Its start command
-fixes Railpack's default jar glob, which doesn't match this project's
-`.war` artifact.
+boot) — then trains a JDK AOT cache (`target/app.aot`, JEP 483/514),
+regenerated every build, best-effort (a failed training run just skips the
+cache, build still succeeds).
 
-Measured locally (extracted WAR, HSQLDB training profile, 5 runs averaged,
-time to the "Started RyyppyApplication" log line):
+The training run boots against a real, throwaway PostgreSQL server that the
+build script starts itself: Railway allows no Docker daemon during a build,
+so the script runs the Postgres server binaries directly on 127.0.0.1 and
+points the `aot-train` profile at them. Training against real Postgres
+rather than an in-memory substitute means the cache covers the same JDBC
+driver, SQL dialect and connection-pool code paths production boots with.
+
+The deploy's start command launches `target/extracted/ryyppynet.jar` — the
+thin jar the build script extracts — rather than letting Railpack pick the
+repackaged `target/ryyppynet.jar` by its default glob. The JDK AOT cache is
+layout-specific, so the artifact that runs has to be the same one the cache
+was trained against.
+
+Measured locally (extracted artifact, HSQLDB training profile — this
+predates the switch to a real Postgres training run above — 5 runs
+averaged, time to the "Started RyyppyApplication" log line):
 
 | Configuration | Startup time | vs. plain boot |
 | --- | --- | --- |
@@ -90,4 +102,5 @@ reflection-based bean discovery, the JDK cache skips class loading/linking —
 so they stack rather than overlap.
 
 Postgres/OAuth2 config is read from env vars exactly as above; the
-training run only ever touches its own throwaway in-memory database.
+training run only ever touches its own throwaway Postgres instance, which
+is deleted when the build step ends.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>net.ryyppy</groupId>
     <artifactId>ryyppynet</artifactId>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <version>3.1.5-SNAPSHOT</version>
     <name>ryyppy.net</name>
     <url>https://ryyppy.net</url>

--- a/railway.json
+++ b/railway.json
@@ -5,6 +5,6 @@
     "buildCommand": "bash scripts/railway-build-aot-cache.sh"
   },
   "deploy": {
-    "startCommand": "java -Dserver.port=$PORT $JAVA_OPTS -jar target/extracted/ryyppynet.war"
+    "startCommand": "java -Dserver.port=$PORT $JAVA_OPTS -jar target/extracted/ryyppynet.jar"
   }
 }

--- a/scripts/railway-build-aot-cache.sh
+++ b/scripts/railway-build-aot-cache.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Railway build command: package the WAR, then do a short training run to
+# Railway build command: package the jar, then do a short training run to
 # produce a JDK AOT cache (JEP 483/514) so the production start command
 # can boot faster. The training run boots against a real, ephemeral
 # PostgreSQL instance that this script starts itself (see the "AOT
@@ -36,28 +36,28 @@ cd "$(dirname "$0")/.."
 echo "==> mvn package"
 mvn -B -DskipTests package
 
-WAR=target/ryyppynet.war
+JAR=target/ryyppynet.jar
 EXTRACTED_DIR=target/extracted
-EXTRACTED_WAR="$EXTRACTED_DIR/ryyppynet.war"
+EXTRACTED_JAR="$EXTRACTED_DIR/ryyppynet.jar"
 AOT_CACHE=target/app.aot
 TRAIN_LOG=target/aot-train.log
 TRAIN_PORT=8080
 
-if [ ! -f "$WAR" ]; then
-  echo "!! $WAR not found after mvn package, aborting" >&2
+if [ ! -f "$JAR" ]; then
+  echo "!! $JAR not found after mvn package, aborting" >&2
   exit 1
 fi
 
-# Extract the WAR into a thin executable WAR plus a flat lib/ directory
+# Extract the jar into a thin executable jar plus a flat lib/ directory
 # (see issue #15). The JDK AOT cache is layout-specific, so it has to be
-# trained against this extracted layout rather than the nested-jar WAR -
-# that's also what the production start command now launches.
-echo "==> extracting WAR"
+# trained against this extracted layout rather than the nested-jar
+# archive - that's also what the production start command now launches.
+echo "==> extracting jar"
 rm -rf "$EXTRACTED_DIR"
-java -Djarmode=tools -jar "$WAR" extract --destination "$EXTRACTED_DIR"
+java -Djarmode=tools -jar "$JAR" extract --destination "$EXTRACTED_DIR"
 
-if [ ! -f "$EXTRACTED_WAR" ]; then
-  echo "!! $EXTRACTED_WAR not found after extraction, aborting" >&2
+if [ ! -f "$EXTRACTED_JAR" ]; then
+  echo "!! $EXTRACTED_JAR not found after extraction, aborting" >&2
   exit 1
 fi
 
@@ -181,7 +181,7 @@ set +e
 env -u SPRING_DATASOURCE_URL -u SPRING_DATASOURCE_USERNAME -u SPRING_DATASOURCE_PASSWORD \
   AOT_TRAIN_PG_PORT="$PG_PORT" \
   java -Dspring.aot.enabled=true -XX:AOTCacheOutput="$AOT_CACHE" \
-  -jar "$EXTRACTED_WAR" \
+  -jar "$EXTRACTED_JAR" \
   --spring.profiles.active=aot-train \
   --server.port="$TRAIN_PORT" \
   > "$TRAIN_LOG" 2>&1 &

--- a/src/main/java/drinkcounter/RyyppyApplication.java
+++ b/src/main/java/drinkcounter/RyyppyApplication.java
@@ -2,16 +2,9 @@ package drinkcounter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class RyyppyApplication extends SpringBootServletInitializer {
-    @Override
-    protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-        return builder.sources(RyyppyApplication.class);
-    }
-
+public class RyyppyApplication {
     public static void main(String[] args) {
         SpringApplication.run(RyyppyApplication.class, args);
     }


### PR DESCRIPTION
Closes #124.

Since #122 retired JSP infrastructure there is no `src/main/webapp`, no JSP/JSTL/Jasper dependency and no `provided`-scoped dependency — every view is a Thymeleaf template on the classpath and static assets are served from `src/main/resources`. Nothing requires deployment into an external servlet container any more, so the artifact becomes a plain Spring Boot jar.

## Changes

- `pom.xml`: `<packaging>war</packaging>` → `jar`.
- `RyyppyApplication`: dropped `extends SpringBootServletInitializer` and the `configure(SpringApplicationBuilder)` override — only needed for external-container deployment.
- `scripts/railway-build-aot-cache.sh`: `WAR`/`EXTRACTED_WAR` → `JAR`/`EXTRACTED_JAR` (`target/ryyppynet.jar`, `target/extracted/ryyppynet.jar`), plus the messages and header comment that described the WAR layout.
- `railway.json`: start command launches `target/extracted/ryyppynet.jar`.
- `README.md`: release/run instructions, and the Railway section — which also claimed the AOT training run boots against an in-memory HSQLDB. It has started a real, throwaway PostgreSQL server since the training profile switched; the section now describes that, and the measurement table is captioned as predating the switch, since those numbers were taken under the HSQLDB profile.
- `CLAUDE.md`: "Build WAR file" → "Build jar file".

The explicit start command is still needed: Railpack's default glob would pick the repackaged `target/ryyppynet.jar`, but the JDK AOT cache is layout-specific and has to run against the extracted thin jar it was trained on.

## Startup time

Both optimizations are unaffected. Spring AOT (`process-aot`) is packaging-agnostic; the JDK AOT cache is sensitive to classpath *layout*, not artifact extension, and train and start both move to the jar in the same commit.

Ran the real Railway build command (`bash scripts/railway-build-aot-cache.sh`) end to end in this container: `mvn package` → jar extraction → ephemeral Postgres → training run → `AOT cache created: target/app.aot (142M)`. Then booted the exact production start command (`java -Dserver.port=$PORT -Dspring.aot.enabled=true -XX:AOTCache=target/app.aot -jar target/extracted/ryyppynet.jar`) against that Postgres with Flyway migrating for real:

| Build | Startup |
| --- | --- |
| This branch, jar + both optimizations | 2.54s |
| `main`, plain WAR boot, no optimizations (control) | 9.00s |

Container timings, so slower than the README's numbers in absolute terms, but the ratio matches what is documented today.

## Testing

- `mvn test` — 73 passed.
- Playwright suite against the running jar: 32/35 passed on the first full run. Two of the three failures passed on an individual re-run (container under load with 4 workers). The third, `party-classic.spec.ts` "add-registered-user form enables its submit button…", fails reproducibly here — but it fails identically against an unmodified `main` WAR build in a git worktree (control), timing out in `pressSequentially` against the 30s budget. It is environmental, not caused by this change.
- Manual checks on the running jar: `/ui/login`, `/actuator/health`, `/static/css/**` and `/webjars/**` all 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162vZGuNC6NbAquhVNUzdmH


---
_Generated by [Claude Code](https://claude.ai/code/session_0162vZGuNC6NbAquhVNUzdmH)_